### PR TITLE
change share name example to transmission-data. Fixes #3

### DIFF
--- a/transmission.json
+++ b/transmission.json
@@ -12,7 +12,7 @@
                 "launch_order": 1,
                 "ports": {
                     "51413": {
-                        "description": "Port used to share the file being downloaded. You may need to open it(protocol: tcp and udp) on your firewall. Suggested default: 51413.",
+                        "description": "Port used to share the file being downloaded. You may need to open it (protocol: tcp and udp) on your firewall. Suggested default: 51413.",
                         "host_default": 51413,
                         "label": "Sharing port"
                     },
@@ -26,7 +26,7 @@
                 },
                 "volumes": {
                     "/var/lib/transmission-daemon": {
-                        "description": "Choose a Share where Transmission will save all of it's files including your downloads. Eg: create a Share called transmission-rockon.",
+                        "description": "Choose a Share where Transmission will save all of it's config and data files including your downloads. Eg: create a Share called transmission-data.",
                         "label": "Data Storage"
                     }
                 },


### PR DESCRIPTION
The suggested share name was previously transmission-rockon
which is confusing as it's only the data and config that uses this
share not the rockon itself which is stored on another specialized
share.

Fixes #3 