### PR TITLE
Initial import of gitlab rock-on

### DIFF
--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -9,14 +9,14 @@
 						"host_default": 8080,
 						"protocol": "tcp",
 						"label": "HTTP WebUI port",
-						"description": "GitLab WebUI port.Suggested default: 8080",
+						"description": "GitLab WebUI port. Suggested default: 8080",
 						"ui":true
 					},
 					"443": {
 						"host_default": 8443,
 						"protocol": "tcp",
 						"label": "HTTPS WebUI port",
-						"description": "GitLab WebUI port.Suggested default: 8443. Not enabled in docker image by default"
+						"description": "GitLab WebUI port. Suggested default: 8443. Not enabled in docker image by default"
 					},
 					"22": {
 						"host_default": 2222,

--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -1,0 +1,51 @@
+{
+	"GitLab CE": {
+		"containers": {
+			"gitlab-ce": {
+				"image": "gitlab/gitlab-ce",
+				"launch_order": 1,
+				"ports": {
+					"80": {
+						"host_default": 8080,
+						"protocol": "tcp",
+						"label": "HTTP WebUI port",
+						"description": "GitLab WebUI port.Suggested default: 8080",
+						"ui":true
+					},
+					"443": {
+						"host_default": 8443,
+						"protocol": "tcp",
+						"label": "HTTPS WebUI port",
+						"description": "GitLab WebUI port.Suggested default: 8443. Not enabled in docker image by default"
+					    },
+					"22": {
+						"host_default": 2222,
+						"protocol": "tcp",
+						"label": "SSH Gitlab port",
+						"description": "GitLab SSH port. Suggested default: 2222"
+					}
+				},
+			"volumes": {
+				"/var/opt/gitlab": {
+					"description": "Choose a Share for GitLab repositories. Eg: create a Share called gitlab-repos for this purpose alone.",
+					"label": "Repository Storage",
+					"min_size": 1073741824
+				},
+				"/etc/gitlab": {
+					"description": "Choose a Share for GitLab configuration. Eg: create a Share called gitlab-config for this purpose alone.",
+					"label": "Config Storage"
+				},
+				"/var/log/gitlab": {
+                                        "description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",
+                                        "label": "Config logs"
+                                }
+			}
+		    }
+		},
+		"description": "Git repository hosting and collaboration",
+		"website": "https://about.gitlab.com/",
+		"icon": "https://about.gitlab.com/images/wordmark.png",
+		"more_info": "<p>Default username for your GitLab UI is<code>root</code>and password is<code>5iveL!fe</code></p><p>HTTPS is not enabled by defautt, please see: <a href='https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md#enable-https'> https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/doc/settings/nginx.md#enable-https</a></p>",
+		"version":"1.1"
+	}
+}

--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -29,15 +29,17 @@
 				"/var/opt/gitlab": {
 					"description": "Choose a Share for GitLab repositories. Eg: create a Share called gitlab-repos for this purpose alone.",
 					"label": "Repository Storage",
-					"min_size": 1073741824
+					"min_size": 1048576
 				},
 				"/etc/gitlab": {
 					"description": "Choose a Share for GitLab configuration. Eg: create a Share called gitlab-config for this purpose alone.",
 					"label": "Config Storage"
+					"min_size": 1048576
 				},
 				"/var/log/gitlab": {
                                         "description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",
                                         "label": "Config logs"
+					"min_size": 1048576
                                 }
 			}
 		    }

--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -17,7 +17,7 @@
 						"protocol": "tcp",
 						"label": "HTTPS WebUI port",
 						"description": "GitLab WebUI port.Suggested default: 8443. Not enabled in docker image by default"
-					    },
+					},
 					"22": {
 						"host_default": 2222,
 						"protocol": "tcp",
@@ -36,10 +36,10 @@
 					"label": "Config Storage"
 				},
 				"/var/log/gitlab": {
-                                        "description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",
+					"description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",
 					"label": "Config logs",
 					"min_size": 1048576
-                                }
+				}
 			}
 		    }
 		},

--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -37,7 +37,7 @@
 				},
 				"/var/log/gitlab": {
                                         "description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",
-                                        "label": "Config logs"
+					"label": "Config logs",
 					"min_size": 1048576
                                 }
 			}

--- a/gitlab-rc.json
+++ b/gitlab-rc.json
@@ -34,7 +34,6 @@
 				"/etc/gitlab": {
 					"description": "Choose a Share for GitLab configuration. Eg: create a Share called gitlab-config for this purpose alone.",
 					"label": "Config Storage"
-					"min_size": 1048576
 				},
 				"/var/log/gitlab": {
                                         "description": "Choose a Share for GitLab log files. Eg: create a Share called gitlab-logs for this purpose alone.",


### PR DESCRIPTION
Initiial import, added port 443 from the comments https://github.com/rockstor/rockstor-core/issues/1025. 443 doesn't respond and requires settings to be changed in the image. 

And i was unable to add two UI buttons, but i guess this is expected.