### PR TITLE
Update btsync.json

### DIFF
--- a/btsync.json
+++ b/btsync.json
@@ -2,7 +2,7 @@
     "BTSync": {
         "containers": {
             "btsync": {
-                "image": "aostanin/btsync",
+                "image": "crewjam/btsync",
                 "launch_order": 1,
                 "ports": {
                     "3369": {


### PR DESCRIPTION
Unable to find image 'aostanin/btsync:latest' locally
Pulling repository docker.io/aostanin/btsync
Error: image aostanin/btsync:latest not found


crewjam/btsync is the btsync image with the most downloads. Propose to use this.