### PR TITLE
Added Go Git Service (Gogs).

### DIFF
--- a/gogs.json
+++ b/gogs.json
@@ -1,0 +1,42 @@
+{
+  "Gogs": {
+    "containers": {
+      "gogs": {
+        "image": "gogs/gogs",
+        "launch_order": 1,
+        "ports": {
+          "22": {
+            "description": "Gogs ssh port. You may need to open it on your firewall if you want access from outside your local network. Suggested default: 3022.",
+            "host_default": 3022,
+            "label": "ssh port",
+            "procotol": "tcp"
+          },
+          "3000": {
+            "description": "Gogs WebUI port. Suggested default: 3000",
+            "host_default": 3000,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/data": {
+            "description": "Choose a Share for gogs configuration and database.",
+            "label": "Config Storage"
+          },
+          "/data/git/gogs-repositories": {
+            "description": "Choose a Share for your git repositories.",
+            "label": "Git Storage"
+          }
+        }
+      }
+    },
+    "description": "Go Git Service, a lightweight Git version control server and front end",
+    "more_info": "<h4>Authentication</h4><p>Gogs will take you through its configuration when first run. You can set an admin username and password then; otherwise, the first user to register will automatically get administrator rights.</p><h4>Configuration</h4><p>Change Domain to reflect your Rockstor server name or IP address. The SSH Port is used for git<code>ssh</code>access and should be changed to the port you configured (3022 by default). Similarly, the HTTP Port (3000 by default) may also require changing. Finally, the Application URL is used for git<code>http</code>access and should reflect the Rockstor server and Gogs Rock-on port.</p><p>Use the SQLite3 database if you don't want to use an external database. Do <em>not</em> change the repository root path (<code>/data/git/gogs-repositories</code>) or the git storage share won't work.</p><h4>Afterwards</h4><p>You can inspect and where necessary modify your configuration in <code>gogs/conf/app.ini</code> on the gogs configuration Share.</p><p>The git Share will host all your git repositories in standard (bare) format, and repositories for any wikis that you create.<p>",
+    "ui": {
+      "slug": ""
+    },
+    "website": "https://gogs.io/",
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
A Rock-On wrapper around the [Gogs](https://gogs.io/) official [gogs/gogs](https://hub.docker.com/r/gogs/gogs/) Docker image as [discussed on the forum](https://forum.rockstor.com/t/rock-on-requests/41/65). 

### The Rock-on
The only aspect worth noting is that I split the data in two shares: the configuration share mounted under `/data` in the Docker image, and the git repository share mounted under `/data/git/gogs-repositories`. The latter contains just bare git repositories, nothing gogs-specific (even its wikis are just repositories).

Only a single git repository volume is supported. Allowing volume add support would require the user to keep Gogs user (or organisation) names and the volumes mounted under `/data/git/gogs-repositories` in sync. Not a great idea, I think.

Let me know if there is anything I can clarify or help with.

### Configuration
Some information for the configuration Gogs takes you through when first run:

You can set an admin username and password during initial configuration; otherwise, the first user to register will automatically get administrator rights.

The `SQLite3` database will be great for most as it avoids the need for more infrastructure.

Change Domain to reflect your Rockstor server name or IP address  - or the public domain name, if you decide to open up your firewall to enable external access. The SSH Port is used for git `ssh` access and should be changed to the port configured (3022 by default). Ditto for the HTTP Port (3000 by default). Finally, the Application URL is used for git `http` access and should reflect the server and Rock-on port.