### PR TITLE
symform entry missing in root. Fixes #29

### DIFF
--- a/root.json
+++ b/root.json
@@ -8,12 +8,12 @@
     "JenkinsCI": "jenkins.json",
     "Logitech Squeezebox": "LogitechSqueezebox.json",
     "NZBGet": "nzbget.json",
-    "OwnCloud": "owncloud.json",
     "OpenVPN": "openvpn.json",
+    "OwnCloud": "owncloud.json",
     "Plex": "plex.json",
-    "Syncthing": "syncthing.json",
     "sabnzb": "sabnzb.json",
     "Sonarr": "sonarr.json",
     "Symform": "symform.json",
+    "Syncthing": "syncthing.json",
     "Transmission": "transmission.json"
 }

--- a/root.json
+++ b/root.json
@@ -14,5 +14,6 @@
     "Syncthing": "syncthing.json",
     "sabnzb": "sabnzb.json",
     "Sonarr": "sonarr.json",
+    "Symform": "symform.json",
     "Transmission": "transmission.json"
 }


### PR DESCRIPTION
@schakrava Found this discrepancy so simple pr to address it. Not sure if I've missed a comment relating to this though.

Consequences as far as I can see are the non appearance of the recently added Symform Rock-on in available Rock-ons.

Not sure how to test these changes though without the repo update so submitting as untested.