### PR TITLE
Add Sickrage rock-on from Linuxserver.io

### DIFF
--- a/Sickrage.json
+++ b/Sickrage.json
@@ -1,0 +1,53 @@
+{
+    "Sickrage": {
+        "containers": {
+            "sickrage": {
+                "image": "linuxserver/sickrage",
+                "launch_order": 1,
+                "ports": {
+                    "8081": {
+                        "description": "Port for Sickrage Web interface. Suggested default: 8081.",
+                        "host_default": 8081,
+                        "label": "WebUI port",
+                        "procotol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/download": {
+                        "description": "Choose a share to download to.",
+                        "label": "Download"
+                    },
+                    "/config": {
+                        "description": "Choose a share to host configuration.",
+                        "label": "Config"
+                    },
+                    "/tv": {
+                        "description": "Choose a share to host shows.",
+                        "label": "TV"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+		        "description": "Enter a valid UID to run sickrage as. It must have full permissions to all Shares mapped in the previous step.",
+                        "label": "UID",
+                        "index": 1
+		    },
+                    "PGID": {
+                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID",
+                        "index": 2
+                    }
+                }
+            }
+        },
+        "description": "Automatic Video Library Manager for TV Shows, by Linuxserver.io",
+        "more_info": "Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "website": "https://hub.docker.com/r/linuxserver/sickrage/",
+        "version": "alpha"
+    }
+}


### PR DESCRIPTION
Based on Sickbeard config. Tested on my own Rockstor installation. Has been running well, snatching, downloading and post processing many, many TV shows successfully over the past 24 hours. Sickrage differs from Sickbeard in that it has much better Torrent support.