### PR TITLE
Daemon Port

### DIFF
--- a/deluge.json
+++ b/deluge.json
@@ -4,14 +4,6 @@
             "Deluge": {
                 "image": "linuxserver/deluge",
                 "launch_order": 1,
-		"opts": [
-                    [
-                    	"--net=host",
-                        "",
-			"-v",
-			"/dev/rtc:/dev/rtc:ro"
-		    ]
-		],
                 "ports": {
                     "8112": {
                         "description": "Deluge WebUI port. Suggested default: 8112",
@@ -33,17 +25,17 @@
                         "description": "Choose a Share for Deluge configuration. Eg: create a Share called Deluge-config for this purpose alone.",
                         "label": "Config Storage"
                     },
-		    "/downloads": {
-                	"description": "Choose a Share for Deluge downloads. Eg: create a Share called Deluge-downloads for this purpose alone.",
-                	"label": "Download Storage"
+            "/downloads": {
+                    "description": "Choose a Share for Deluge downloads. Eg: create a Share called Deluge-downloads for this purpose alone.",
+                    "label": "Download Storage"
                     }
                 },
                 "environment": {
                     "PUID": {
-		        "description": "Enter a valid UID to run Deluge as. It must have full permissions to all Shares mapped in the previous step.",
+                "description": "Enter a valid UID to run Deluge as. It must have full permissions to all Shares mapped in the previous step.",
                         "label": "UID to run Deluge as.",
                         "index": 1
-		    },
+            },
                     "PGID": {
                         "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
                         "label": "GID to run Deluge as.",
@@ -53,12 +45,12 @@
             }
         },
         "description": "Deluge is a movie downloader for bittorrent users.",
-	"more_info": "<h4>Default username: admin</p>Default password: deluge. Also for daemonusage with CP etc. visit https://couchpota.to/forum/viewtopic.php?t=4158, and edit authfile found in config folder.",
+        "more_info": "Default username: admin<br>Default password: deluge.",
         "ui": {
             "slug": ""
         },
         "volume_add_support": true,
-	"website": "https://hub.docker.com/r/linuxserver/deluge/",
-	"version": "1.0"
+    "website": "https://hub.docker.com/r/linuxserver/deluge/",
+    "version": "1.0"
     }
 }

--- a/deluge.json
+++ b/deluge.json
@@ -19,6 +19,13 @@
                         "label": "WebUI port",
                         "protocol": "tcp",
                         "ui": true
+                    },
+                    "58846": {
+                        "description": "Deluge Daemon port. Suggested default: 58846",
+                        "host_default": 58846,
+                        "label": "Daemon port",
+                        "protocol": "tcp",
+                        "ui": true
                     }
                 },
                 "volumes": {


### PR DESCRIPTION
allow access to the daemon,
since if you can't automate these actions and need to do everything through the web-ui, it just makes the whole thing a bit obsolete.
