### PR TITLE
syncthing port update to track upstream changes, thanks @fago. Fixes #40

### DIFF
--- a/syncthing.json
+++ b/syncthing.json
@@ -5,9 +5,9 @@
                 "image": "istepanov/syncthing",
                 "launch_order": 1,
                 "ports": {
-                    "21025": {
-                        "description": "Port for discovery broadcasts. You may need to open it(protocol: udp) on your firewall. Suggested default: 21025.",
-                        "host_default": 21025,
+                    "21027": {
+                        "description": "Port for discovery broadcasts. You may need to open it(protocol: udp) on your firewall. Suggested default: 21027.",
+                        "host_default": 21027,
                         "label": "Discovery port",
                         "protocol": "udp"
                     },


### PR DESCRIPTION
Thanks to @fago for bringing to light the recent change in discovery port for upstream syncthing as per version v0.12 onwards from 21025 to 21027.
https://docs.syncthing.net/users/firewall.html#local-firewall
and
syncthing/syncthing#2685 (comment)

As of 16 days before @fago 's pull requests has been merged:-
https://github.com/istepanov/docker-syncthing/pull/3
and the consequent Dockerfile on Docker Hub has also been updated:-
https://hub.docker.com/r/istepanov/syncthing/~/dockerfile/
The build details for this image indicate an update 16 days ago followed
by another 4 days ago.

So updating the 21025 entries in syncthing.json to reflect these upstream changes.

Fixes #40 