### PR TITLE
add UID to transmission rockon

### DIFF
--- a/transmission.json
+++ b/transmission.json
@@ -42,6 +42,16 @@
                         "label": "WebUI password",
                         "default": "admin",
                         "index": 2
+		    },
+		    "USERID": {
+			"description": "Choose a UID to run transmission as.",
+			"label": "UID",
+			"index": 3
+		    },
+		    "GROUPID": {
+			"description": "Choose a GID to run transmission as.",
+			"label": "GID",
+			"index": 4
                     }
                 }
             }


### PR DESCRIPTION
Transmission currently will set 104:107 by default which usually is not created on the host system.  This resolves inside the containers to debian-transmission.  The issue is that you need to start adding other users to group or have 104:107 set on other rockons to enable them to use the volume from transmission.  This should enable you to do that by setting the UID/GID on creation for transmission. The environment variables added are supported and listed on the github for this rockon - https://github.com/dperson/transmission
This is also a fix for this issue - https://forum.rockstor.com/t/automatically-changing-owner-on-share/1939