### PR TITLE
Fix broken URL for Transmission website

### DIFF
--- a/transmission.json
+++ b/transmission.json
@@ -6,7 +6,7 @@
             "slug": ""
         },
         "version": "1.0",
-        "website": "http: //www.transmissionbt.com/",
+        "website": "http://www.transmissionbt.com/",
         "containers": {
             "transmission": {
                 "image": "dperson/transmission",


### PR DESCRIPTION
there was an errant space in the middle of the link