### PR TITLE
Correct Website URL

### DIFF
--- a/NZBHydra.json
+++ b/NZBHydra.json
@@ -42,7 +42,7 @@
             "slug": ""
         },
         "volume_add_support": true,
-	"website": "https://hub.docker.com/r/linuxserver/nzbhydra/",
+	"website": "https://hub.docker.com/r/linuxserver/hydra/",
 	"version": "1.0"
     }
 }


### PR DESCRIPTION
Correct website url to https://hub.docker.com/r/linuxserver/hydra/ from https://hub.docker.com/r/linuxserver/nzbhydra/