### PR TITLE
Zabbix xxl

### DIFF
--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -15,6 +15,12 @@
                 "image": "busybox",
                 "label": "latest",
                 "launch_order": 1,
+                "opts": [
+		            [
+			            "--restart",
+			            "no"
+		            ]
+		        ],
                 "volumes": {
                     "/var/lib/mysql": {
                         "description": "Choose a Share for Zabbix Database. (create a share called zabbix-db for this purpose)",

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -104,7 +104,7 @@
                 "environment": {}
             }
         },
-        "description": "Compiled Zabbix (server, proxy, agent, java gateway, snmpd daemon) with almost all features (MySQL support, Java, SNMP, Curl, Ipmi, SSH, fping) and Zabbix web UI based on CentOS 7, Supervisor, Nginx, PHP.",
+        "description": "Compiled Zabbix Server (and proxy, agent, java gateway, snmpd daemon) with almost all features (MySQL support, Java, SNMP, Curl, Ipmi, SSH, fping) and Zabbix web UI based on CentOS 7, Supervisor, Nginx, PHP.",
         "ui": {
             "https": false,
             "slug": ""

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -51,10 +51,6 @@
                     [
                         "--volumes-from",
                         "zabbix-db-storage"
-                    ],
-                    [
-                        "-v",
-                        "/etc/localtime:/etc/localtime:ro"
                     ]
                 ],
                 "environment": {}
@@ -101,10 +97,6 @@
                     [
                         "--link",
                         "zabbix-db:zabbix.db"
-                    ],
-                    [
-                        "-v",
-                        "/etc/localtime:/etc/localtime:ro"
                     ]
                 ],
                 "environment": {}

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -49,8 +49,8 @@
                 ],
                 "environment": {
                     "MARIADB_PASS": {
-                        "description": "MariaDB Password",
-                        "label": "MariaDB Password"
+                        "description": "MariaDB Password (enter twice)",
+                        "label": "MariaDB Password (enter twice)"
                     }
                  }
             },
@@ -94,8 +94,8 @@
                 ],
                 "environment": {
                     "ZS_DBPassword": {
-                        "description": "MariaDB Password (enter again)",
-                        "label": "MariaDB Password (enter again)"
+                        "description": "MariaDB Password (enter twice)",
+                        "label": "MariaDB Password (enter twice)"
                      }
                 }
             }

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -1,0 +1,113 @@
+{
+    "Zabbix-XXL": {
+        "container_links": {
+            "zabbix": [{
+                "name": "zabbox.db",
+                "source_container": "zabbix-db"
+            }],
+            "zabbix-db": [{
+                "name": "zabbix-db-storage",
+                "source_container": "zabbix-db-storage"
+            }]
+        },
+        "containers": {
+            "zabbix-db-storage": {
+                "image": "busybox",
+                "label": "latest",
+                "launch_order": 1,
+                "volumes": {
+                    "/var/lib/mysql": {
+                        "description": "Choose a Share for Zabbix Database,. E.g. create a Share called zabbix-db for this purpose.",
+                        "label": "Zabbix Database",
+                        "min_size": "1073741824"
+                    }
+                }
+            },
+            "zabbix-db": {
+                "image": "monitoringartist/zabbix-db-mariadb",
+                "launch_order": 2,
+                "volumes": {
+                    "/backups": {
+                        "description": "Choose a Share for Zabbix Backups. E.g. create a Share called zabbix-backups for this purpose.",
+                        "label": "Zabbix Backups",
+                        "min_size": "1073741824"
+                    }
+                },
+                "opts": [
+                    [
+                        "-e",
+                        "MARIADB_USER=zabbix"
+                    ],
+                    [
+                        "--volumes-from",
+                        "zabbix-db-storage"
+                    ],
+                    [
+                        "-v",
+                        "/etc/localtime:/etc/localtime:ro"
+                    ]
+                ],
+                "environment": {
+                    "MARIADB_PASS": {
+                        "description": "MariaDB Password",
+                        "label": "MariaDB Password"
+                    }
+                 }
+            },
+            "zabbix": {
+                "image": "monitoringartist/zabbix-xxl",
+                "label": "latest",
+                "launch_order": 3,
+                "ports": {
+                    "80": {
+                        "description": "Zabbix Server Web Interface (Suugested default:8080)",
+                        "host_default": 80,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    },
+                    "10051": {
+                        "description": "Zabbix Server API Port (default:10051)",
+                        "host_default": 10051,
+                        "label": "API Port",
+                        "protocol": "tcp",
+                        "ui": false
+                    }
+                },
+                "opts": [
+                    [
+                        "-e",
+                        "ZS_DBHost=zabbix.db"
+                    ],
+                    [
+                        "-e",
+                        "ZS_DBUser=zabbix"
+                    ],
+                    [
+                        "--link",
+                        "zabbix-db:zabbix.db"
+                    ],
+                    [
+                        "-v",
+                        "/etc/localtime:/etc/localtime:ro"
+                    ]
+                ],
+                "environment": {
+                    "ZS_DBPassword": {
+                        "description": "MariaDB Password (enter again)",
+                        "label": "MariaDB Password (enter again)"
+                     }
+                }
+            }
+        },
+        "description": "Compiled Zabbix (server, proxy, agent, java gateway, snmpd daemon) with almost all features (MySQL support, Java, SNMP, Curl, Ipmi, SSH, fping) and Zabbix web UI based on CentOS 7, Supervisor, Nginx, PHP.",
+        "ui": {
+            "https": false,
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "more_info": "<h4>More Information</h4><p>please check the link for backups and troubleshooting if needed</p>",
+        "website": "https://hub.docker.com/r/monitoringartist/zabbix-xxl/",
+        "version": "1.0"
+    }
+}

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -17,7 +17,7 @@
                 "launch_order": 1,
                 "volumes": {
                     "/var/lib/mysql": {
-                        "description": "Choose a Share for Zabbix Database,. E.g. create a Share called zabbix-db for this purpose.",
+                        "description": "Choose a Share for Zabbix Database. (create a share called zabbix-db for this purpose)",
                         "label": "Zabbix Database",
                         "min_size": "1073741824"
                     }
@@ -28,7 +28,7 @@
                 "launch_order": 2,
                 "volumes": {
                     "/backups": {
-                        "description": "Choose a Share for Zabbix Backups. E.g. create a Share called zabbix-backups for this purpose.",
+                        "description": "Choose a Share for Zabbix Backups. (create a share called zabbix-backups for this purpose)",
                         "label": "Zabbix Backups",
                         "min_size": "1073741824"
                     }
@@ -57,6 +57,12 @@
                 "image": "monitoringartist/zabbix-xxl",
                 "label": "latest",
                 "launch_order": 3,
+                "volumes": {
+                    "/etc/custom-config": {
+                        "description": "Choose a share for any custom config files. (create a share called zabbix-config for this puporse)",
+                        "label": "Zabbix Custom Config"
+                    }
+                },
                 "ports": {
                     "80": {
                         "description": "Zabbix Server Web Interface (Suugested default:8080)",

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -47,12 +47,7 @@
                         "/etc/localtime:/etc/localtime:ro"
                     ]
                 ],
-                "environment": {
-                    "MARIADB_PASS": {
-                        "description": "MariaDB Password (enter twice)",
-                        "label": "MariaDB Password (enter twice)"
-                    }
-                 }
+                "environment": {}
             },
             "zabbix": {
                 "image": "monitoringartist/zabbix-xxl",
@@ -92,12 +87,17 @@
                         "/etc/localtime:/etc/localtime:ro"
                     ]
                 ],
-                "environment": {
-                    "ZS_DBPassword": {
-                        "description": "MariaDB Password (enter twice)",
-                        "label": "MariaDB Password (enter twice)"
-                     }
-                }
+                "environment": {}
+            }
+        },
+        "custom_config": {
+            "ZS_DBPassword": {
+                "description": "Database Password",
+                "label": "Database Password (enter twice)"
+            },
+            "MARIADB_PASS": {
+                "description": "Database Password",
+                "label": "Database Password (enter twice)"
             }
         },
         "description": "Compiled Zabbix (server, proxy, agent, java gateway, snmpd daemon) with almost all features (MySQL support, Java, SNMP, Curl, Ipmi, SSH, fping) and Zabbix web UI based on CentOS 7, Supervisor, Nginx, PHP.",

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -39,6 +39,10 @@
                         "MARIADB_USER=zabbix"
                     ],
                     [
+                        "-e",
+                        "MARIADB_PASS=766a2bb5d24bddae466c572bcabca3ee"
+                    ],
+                    [
                         "--volumes-from",
                         "zabbix-db-storage"
                     ],
@@ -79,6 +83,10 @@
                         "ZS_DBUser=zabbix"
                     ],
                     [
+                        "-e",
+                        "ZS_DBPassword=766a2bb5d24bddae466c572bcabca3ee"
+                    ],
+                    [
                         "--link",
                         "zabbix-db:zabbix.db"
                     ],
@@ -88,16 +96,6 @@
                     ]
                 ],
                 "environment": {}
-            }
-        },
-        "custom_config": {
-            "ZS_DBPassword": {
-                "description": "Database Password",
-                "label": "Database Password (enter twice)"
-            },
-            "MARIADB_PASS": {
-                "description": "Database Password",
-                "label": "Database Password (enter twice)"
             }
         },
         "description": "Compiled Zabbix (server, proxy, agent, java gateway, snmpd daemon) with almost all features (MySQL support, Java, SNMP, Curl, Ipmi, SSH, fping) and Zabbix web UI based on CentOS 7, Supervisor, Nginx, PHP.",


### PR DESCRIPTION
Zabbix XXL sets up a full Zabbix Server and MariaDB using three containers linked.  I was pretty impressed this worked and wanted to share.  It should be noted the DB container uses 1 GB memory though (but that's listed in the readme on the docker page). The password has to be hardcoded as we can't grab variables and hardcode at the same time.  Attempting to pass them did not work so I generated a hash to make the hardcoded DB password somewhat complex.  Considering the database is not using a mapped port and restricted to localhost, this should be secure enough to use I hope.