### PR TITLE
Update Subsonic package name

### DIFF
--- a/subsonic.json
+++ b/subsonic.json
@@ -2,7 +2,7 @@
     "Subsonic": {
         "containers": {
             "subsonic": {
-                "image": "hurricane/docker-subsonic",
+                "image": "hurricane/subsonic",
                 "launch_order": 1,
                 "ports": {
                     "4040": {


### PR DESCRIPTION
`hurricane/docker-subsonic` doesn't exist on docker.io, but `hurricane/subsonic` does.
Likely an outdated reference.