### PR TITLE
add resilio sync rock-on

### DIFF
--- a/resilioSync.json
+++ b/resilioSync.json
@@ -1,0 +1,39 @@
+{
+  "Resilio Sync": {
+    "containers": {
+      "resilio-sync": {
+        "image": "resilio/sync",
+        "launch_order": 1,
+        "ports": {
+          "55555": {
+            "description": "Port for incoming data. You may need to open it(protocol: udp) on your firewall. Suggested default: 55555. Should NOT be changed",
+            "host_default": 55555,
+            "label": "Listening port",
+            "procotol": "udp"
+          },
+          "8888": {
+            "description": "Resilio Sync WebUI port. Suggested default: 8888",
+            "host_default": 8888,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/mnt/sync": {
+            "description": "Choose a Share for all incoming data including app state and config. Eg: create a Share called resiliosync-data for this purpose alone. It will be available as /mnt/sync inside Resilio Sync.",
+            "label": "Data Storage"
+          }
+        }
+      }
+    },
+    "description": "Fast, private file sharing for teams and individuals.",
+    "more_info": "<h4>Note about mapping Rockstor Shares</h4><p>Resilio Sync supports mapping more Shares into the Rock-On via the Add Storage button. But, the Rock-on Directory must be a subdirectory of /mnt/mounted_folders. Eg: /mnt/mounted_folders/Photos. Shares mapped to other directories will not be visible.</p>",
+    "ui": {
+      "slug": ""
+    },
+    "version": "1.0",
+    "volume_add_support": true,
+    "website": "https://www.resilio.com/"
+  }
+}


### PR DESCRIPTION
To fix #117 

Tested locally, working fine.

It uses the official Docker container: https://hub.docker.com/r/resilio/sync/

To update an existing btsync rock-on installation: 

- uninstall btsync rock-on
- install resilio sync rock-on
- use the same configuration as for your previous btsync installation (ports and share(s)).