### PR TITLE
Adding in minio.io storage provider.

### DIFF
--- a/minio.json
+++ b/minio.json
@@ -1,0 +1,52 @@
+{
+    "Minio": {
+        "containers": {
+            "Minio": {
+                "image": "jhardison/rockstor-minio",
+                "launch_order": 1,
+                "ports": {
+                    "9000": {
+                        "description": "Port for Minio services including API and Portal access. Suggested default: 9000",
+                        "host_default": 9000,
+                        "label": "Minio main port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/root/.minio": {
+                        "description": "Minio configuration share.",
+                        "label": "Config Storage",
+                        "min_size": 1073741824
+                    },
+                    "/export": {
+                        "description": "Choose a share for all data in Minio.",
+                        "label": "Data Storage"
+                    }
+                },
+                "environment":{
+                    "MINIO_ACCESS_KEY":{
+                        "description": "Custom username or access key of 5 to 20 characters in lenght.",
+                        "label": "Custom Access Key"
+                    },
+                    "MINIO_SECRET_KEY":{
+                        "description": "Custom password or secret key of 8 to 40 characters in length.",
+                        "label": "Custom Secret Key"
+                    },
+                    "MINIO_BROWSER":{
+                        "description": "To disable web browser access, set this value to 'off'. Otherwise set to 'on'.",
+                        "label": "Web Browser Access"
+                    }
+                }
+            }
+        },
+        "description": "Minio is a distributed object storage server built for cloud applications and devops.",
+        "ui": {
+            "https": false,
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "website": "https://minio.io",
+	"version": "1.0"
+    }
+}


### PR DESCRIPTION
Minio.io is a distributed object storage server providing S3 compatibility.
I was not able to find where I can enter a launch command for docker run outside of what I saw in the core code that had custom extends for specific images. So I've created a custom docker image that sources from minio/minio and changes the launch to server mode. (Build hooks set to minio/minio so it will always remain up to date with core.)

This container will expose 9000/tcp and use several environment variables to turn on the portal and set user/pass. (The user and password get generated automatically if not defined, which would be in the console log of the container and not exposed.)

Check http://minio.io for more info.

Testing simply can be performed by enabling the web ui, and then interacting with the portal. Otherwise you can follow examples for console or code from minio.io. 