### PR TITLE
Add Transmission + OpenVPN Rock-on.

### DIFF
--- a/root.json
+++ b/root.json
@@ -46,6 +46,7 @@
     "TeamSpeak3": "teamspeak3.json",
     "TFTP server": "tftpserver.json",
     "Transmission": "transmission.json",
+    "Transmission + OpenVPN client": "transmission-openvpn.json",
     "Unifi Controller": "unifi.json",
     "Xeoma Video Surveillance": "xeoma.json",
     "ZoneMinder": "zoneminder.json",

--- a/transmission-openvpn.json
+++ b/transmission-openvpn.json
@@ -1,0 +1,93 @@
+{
+    "Transmission - OpenVPN": {
+        "website": "https://hub.docker.com/r/haugene/transmission-openvpn/",
+        "version": "1.0",
+        "description": "Docker container running Transmission torrent client with WebUI while connecting to OpenVPN",
+        "more_info": "<p>See the container's documentation for a list of included VPN provider profiles. If your provider isn't included, set it up as a custom provider, by putting the relevant files in the <code>Custom profile</code> share.</p>",
+        "containers": {
+            "transmission-openvpn": {
+                "image": "haugene/transmission-openvpn",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "-v",
+                        "/etc/localtime:/etc/localtime:ro"
+                    ],
+                    [
+                        "--cap-add",
+                        "NET_ADMIN"
+                    ],
+                    [
+                        "--device",
+                        "/dev/net/tun"
+                    ]
+                ],
+                "volumes": {
+                    "/data": {
+                        "description": "Choose a Share where Transmission will save all of it's config and data files including your downloads. Eg: create a Share called transmission-data.",
+                        "label": "Data Storage"
+                    },
+                    "/etc/openvpn/custom": {
+                        "description": "Choose a Share where a set of custom OpenVPN profile files can be found. This can be an empty share if you use one of the included provider profiles.",
+                        "label": "OpenVPN config"
+                    }
+                },
+                "ports": {
+                    "9091": {
+                        "description": "Transmission web UI port (proxied)",
+                        "host_default": 9091,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "environment": {
+                    "OPENVPN_PROVIDER": {
+                        "description": "OpenVPN Provider, in uppercase",
+                        "label": "OPENVPN_PROVIDER",
+                        "default": "CUSTOM",
+                        "index": 1
+                    },
+                    "OPENVPN_CONFIG": {
+                        "description": "Provider config name; 'default' is a safe bet",
+                        "label": "OPENVPN_CONFIG",
+                        "default": "default",
+                        "index": 2
+                    },
+                    "OPENVPN_USERNAME": {
+                        "description": "Your VPN username",
+                        "label": "OPENVPN_USERNAME",
+                        "index": 3
+                    },
+                    "OPENVPN_PASSWORD": {
+                        "description": "Your VPN password",
+                        "label": "OPENVPN_PASSWORD",
+                        "index": 4
+                    },
+                    "OPENVPN_OPTS": {
+                        "description": "OpenVPN options",
+                        "label": "OPENVPN_OPTS",
+                        "default": "--inactive 3600 --ping 10 --ping-exit 60",
+                        "index": 5
+                    },
+                    "LOCAL_NETWORK": {
+                        "description": "IP range (in CIDR notation, e.g. 192.168.0.0/24) to consider 'local'; this range is added to the routing, so that the web UI can be used.",
+                        "label": "LOCAL_NETWORK",
+                        "default": "",
+                        "index": 6
+                    },
+                    "PUID": {
+                        "description": "Choose a User ID to run Transmission as",
+                        "label": "User ID",
+                        "index": 7
+                    },
+                    "PGID": {
+                        "description": "Choose a Group ID to run Transmission as",
+                        "label": "Group ID",
+                        "index": 8
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I wanted to be able to use Transmission through an OpenVPN tunnel, and implementing [haugene/docker-transmission-openvpn](haugene/docker-transmission-openvpn) as a Rock-on seemed like the easiest way to do it.

To keep things flexible, I've added a "custom" OpenVPN profile share by default, allowing you to add your own `.ovpn` files (and the certs and keys that come with it, if you don't inline it) as outlines [here](https://github.com/haugene/docker-transmission-openvpn#using-a-custom-provider).

I've only tested it with the VPN provider I have (VPN-Secure); I assume it works with other providers as well (as well as the original Docker container would), but I'd like some folks with VPNs to test that, if possible.