### PR TITLE
Fix STUN port protocol

### DIFF
--- a/unifi.json
+++ b/unifi.json
@@ -44,7 +44,7 @@
                         "description": "STUN Port. Suggested default: 3478",
                         "host_default": 3478,
                         "label": "STUN Port",
-                        "protocol": "tcp",
+                        "protocol": "udp",
                         "ui": false
                     }
                 },


### PR DESCRIPTION
According to Ubiquity, the STUN port is UDP not TCP. This fixes errors of "STUN Communication Failed" from adopted devices.