### PR TITLE
Watchtower

### DIFF
--- a/watchtower.json
+++ b/watchtower.json
@@ -1,0 +1,23 @@
+{
+  "Watchtower": {
+    "website": "https://hub.docker.com/r/v2tec/watchtower/",
+    "version": "1.0",
+    "description": "Watchtower watches your containers and automatically restarts & updates them whenever their image is refreshed.",
+    "containers": {
+      "watchtower": {
+        "image": "v2tec/watchtower",
+        "launch_order": 1,
+        "opts": [
+          [
+            "-v",
+            "/var/run/docker.sock:/var/run/docker.sock"
+          ],
+          [
+            "--privileged",
+            ""
+          ]
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Watchtower is a container that monitors your local images for updates on dockerhub and the likes. If an image on dockerhub is detected to be newer then your local image. It will stop, pull, start your container(s) so they stay up to date.