### PR TITLE
Smokeping

### DIFF
--- a/smokeping.json
+++ b/smokeping.json
@@ -2,7 +2,10 @@
 	"SmokePing": {
 		"website": "https://hub.docker.com/r/linuxserver/smokeping/",
 		"version": "1.0",
-        "description": "SmokePing is a network latency history monitor.",
+		"description": "SmokePing is a network latency history monitor.",
+		"ui": {
+			"slug": "smokeping/smokeping.cgi"
+		},
 		"containers": {
 			"SmokePing": {
 				"image": "linuxserver/smokeping",
@@ -13,10 +16,7 @@
 						"description": "SmokePing WebUI port. Suggested default: 7878",
 						"host_default": 80,
 						"label": "WebUI port",
-						"protocol": "tcp",
-						"ui": {
-							"slug": "smokeping/smokeping.cgi"
-						}
+						"protocol": "tcp"
 					}
 				},
 				"volumes": {

--- a/smokeping.json
+++ b/smokeping.json
@@ -14,7 +14,9 @@
 						"host_default": 80,
 						"label": "WebUI port",
 						"protocol": "tcp",
-						"ui": true
+						"ui": {
+							"slug": "smokeping/smokeping.cgi"
+						}
 					}
 				},
 				"volumes": {

--- a/smokeping.json
+++ b/smokeping.json
@@ -1,0 +1,46 @@
+{
+	"SmokePing": {
+		"website": "https://hub.docker.com/r/linuxserver/smokeping/",
+		"version": "1.0",
+        "description": "SmokePing is a network latency history monitor.",
+		"containers": {
+			"SmokePing": {
+				"image": "linuxserver/smokeping",
+				"launch_order": 1,
+				"volume_add_support": true,
+				"ports": {
+					"80": {
+						"description": "SmokePing WebUI port. Suggested default: 7878",
+						"host_default": 80,
+						"label": "WebUI port",
+						"protocol": "tcp",
+						"ui": true
+					}
+				},
+				"volumes": {
+					"/config": {
+						"description": "Choose a Share for SmokePing Configuration Files",
+						"label": "Config Storage"
+					},
+					"/data": {
+						"description": "Choose a Share for SmokePing Data Files",
+						"label": "Data location"
+					}
+				},
+				"environment": {
+					"PUID": {
+						"description": "Enter a valid UID to run SmokePing as. It must have full permissions to all Shares mapped in the previous step.",
+						"label": "UID to run SmokePing as.",
+						"index": 1
+					},
+					"PGID": {
+						"description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+						"label": "GID to run SmokePing as.",
+						"index": 2
+					}
+				}
+			}
+		},
+		"volume_add_support": true
+	}
+}


### PR DESCRIPTION
Smokeping is a network monitor and history graph.  You can setup multiple sites for it to ping. It will log the latency and graph it for historical purposes. This is a must for anyone having issues with random latency or ISP issues. This container can NOT be ran as root.

Note: "slug": "smokeping/smokeping.cgi" does not seem to work the FQURL should be host:port/smokeping/smokeping.cgi