### PR TITLE
Add ZeroNet Rockon

### DIFF
--- a/ZeroNet.json
+++ b/ZeroNet.json
@@ -1,0 +1,44 @@
+{
+    "ZeroNet": {
+        "containers": {
+            "zeronet": {
+                "image": "nofish/zeronet",
+                "launch_order": 1,
+                "ports": {
+                    "15441": {
+                        "description": "Port for ZeroNet network connection. You may need to open it (TCP and UDP) on your firewall. Suggested default: 15441.",
+                        "host_default": 15441,
+                        "label": "Listening port"
+                    },
+                    "43110": {
+                        "description": "ZeroNet Web UI Port. Default is 43110",
+                        "host_default": 43110,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/root/data": {
+                        "description": "Choose a share for all ZeroNet data (sites, profiles, etc)",
+                        "label": "Data Storage"
+                    }
+                },
+		"environment": {
+		    "ENABLE_TOR": {
+			"description": "Specify whether or not to enable Tor. Must be 'true' or 'false'.",
+			"label": "ENABLE_TOR",
+			"index": 1
+		    }
+		}
+            }
+        },
+        "description": "Decentralized websites using Bitcoin crypto and the BitTorrent network - https://zeronet.io",
+        "ui": {
+            "https": false,
+            "slug": ""
+        },
+        "website": "https://zeronet.io",
+	"version": "1.0"
+    }
+}


### PR DESCRIPTION
This is to add support for the https://zeronet.io project.

It allows you to setup a Rockon (and associated share) to browse the decentralized, Bitcoin/BitTorrent based, peer-to-peer web.

Tested on my local machine, works like a charm.