### PR TITLE
Add nginx rockon

### DIFF
--- a/nginx.json
+++ b/nginx.json
@@ -1,0 +1,44 @@
+{
+	"nginx": {
+		"description": "Open source reverse proxy server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a web server.",
+		"version": "1.0.0",
+		"website": "https://www.nginx.com/",
+		"icon": "https://cdn-1.wp.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.svg",
+		"more_info": "At startup the config file named default.conf gets created in the config volume if the directory is empty. Extend it with your own custom configuration.<br/>An example configuration file can be found <a href='https://www.nginx.com/resources/wiki/start/topics/examples/full/'>in the nginx wiki</a>. The config volume can be refered as <pre>/config</pre>",
+		"containers": {
+			"nginx": {
+				"image": "jtarka/nginx",
+				"tag": "latest",
+				"launch_order": 1,
+				"ports": {
+					"80": {
+						"description": "HTTP port",
+						"host_default": 1080,
+						"label": "HTTP port",
+						"protocol": "tcp",
+						"ui": true
+					},
+					"443": {
+						"description": "HTTPS port.",
+						"host_default": 1443,
+						"label": "HTTPS port",
+						"protocol": "tcp",
+						"ui": true
+					}
+				},
+				"volumes": {
+					"/config": {
+						"description": "Choose a Share for the nginx configuration. Eg: create a Share called nginx-config for this purpose alone.",
+						"label": "Config Storage",
+						"min_size": 10240
+					},
+					"/usr/share/nginx/html": {
+						"description": "Choose a Share for the files that nginx will serve (HTML, JavaScript, etc.). Eg: create a share called nginx-data for this purpose alone.",
+						"label": "Served Content Storage",
+						"min_size": 102400
+					}
+				}
+			}
+		}
+	}
+}

--- a/nginx.json
+++ b/nginx.json
@@ -1,10 +1,10 @@
 {
 	"nginx": {
-		"description": "Open source web server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a reverse proxy server.<p>Advanced users only: You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>add a default config file to your "Config Storage" share.</a>.</p><p>Based on the official Nginx docker image: <a href='https://hub.docker.com/_/nginx' target='_blank'>https://hub.docker.com/_/nginx</a>.</p>",
+		"description": "Open source web server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a reverse proxy server.<p>Advanced users only: You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388' target='_blank'>add a default config file to your Config Storage share.</a>.</p><p>Based on the official Nginx docker image: <a href='https://hub.docker.com/_/nginx' target='_blank'>https://hub.docker.com/_/nginx</a>.</p>",
 		"version": "1.0.0",
 		"website": "https://www.nginx.com/",
 		"icon": "https://cdn-1.wp.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.svg",
-		"more_info": "You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>create a default config file</a> in the Config Storage share before starting this Rockon, which you can extend with your own custom configuration.<br/>For advanced users, an example configuration file can be found <a href='https://www.nginx.com/resources/wiki/start/topics/examples/full/'>in the nginx wiki</a>. The config volume is mounted at <pre>/etc/nginx/conf.d/</pre>",
+		"more_info": "You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388' target='_blank'>create a default config file</a> in the Config Storage share before starting this Rockon, which you can extend with your own custom configuration.<br/>For advanced users, an example configuration file can be found <a href='https://www.nginx.com/resources/wiki/start/topics/examples/full/' target='_blank'>in the nginx wiki</a>.",
 		"containers": {
 			"nginx": {
 				"image": "nginx",
@@ -23,7 +23,6 @@
 						"host_default": 1443,
 						"label": "HTTPS port",
 						"protocol": "tcp",
-						"ui": true
 					}
 				},
 				"volumes": {

--- a/nginx.json
+++ b/nginx.json
@@ -1,6 +1,6 @@
 {
 	"nginx": {
-		"description": "Open source web server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a reverse proxy server.<p>Advanced users only: You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388' target='_blank'>add a default config file to your Config Storage share.</a>.</p><p>Based on the official Nginx docker image: <a href='https://hub.docker.com/_/nginx' target='_blank'>https://hub.docker.com/_/nginx</a>.</p>",
+		"description": "Open source web server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a reverse proxy server.<p>Advanced users only: You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388' target='_blank'>add a default config file</a> to your Config Storage share.</p><p>Based on the official Nginx docker image: <a href='https://hub.docker.com/_/nginx' target='_blank'>https://hub.docker.com/_/nginx</a>.</p>",
 		"version": "1.0.0",
 		"website": "https://www.nginx.com/",
 		"icon": "https://cdn-1.wp.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.svg",
@@ -22,7 +22,7 @@
 						"description": "HTTPS port.",
 						"host_default": 1443,
 						"label": "HTTPS port",
-						"protocol": "tcp",
+						"protocol": "tcp"
 					}
 				},
 				"volumes": {

--- a/nginx.json
+++ b/nginx.json
@@ -4,10 +4,10 @@
 		"version": "1.0.0",
 		"website": "https://www.nginx.com/",
 		"icon": "https://cdn-1.wp.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.svg",
-		"more_info": "At startup the config file named default.conf gets created in the config volume if the directory is empty. Extend it with your own custom configuration.<br/>An example configuration file can be found <a href='https://www.nginx.com/resources/wiki/start/topics/examples/full/'>in the nginx wiki</a>. The config volume can be refered as <pre>/config</pre>",
+		"more_info": "You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>create a default config file</a> in the Config Storage share before starting this Rockon, which you can extend with your own custom configuration.<br/>For advanced users, an example configuration file can be found <a href='https://www.nginx.com/resources/wiki/start/topics/examples/full/'>in the nginx wiki</a>. The config volume is mounted at <pre>/etc/nginx/conf.d/</pre>",
 		"containers": {
 			"nginx": {
-				"image": "jtarka/nginx",
+				"image": "nginx",
 				"tag": "latest",
 				"launch_order": 1,
 				"ports": {
@@ -27,8 +27,8 @@
 					}
 				},
 				"volumes": {
-					"/config": {
-						"description": "Choose a Share for the nginx configuration. Eg: create a Share called nginx-config for this purpose alone.",
+					"/etc/nginx/conf.d": {
+						"description": "Choose a Share for the nginx configuration. Eg: create a Share called nginx-config for this purpose alone.<br/>You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>add a default config file</a>.",
 						"label": "Config Storage",
 						"min_size": 10240
 					},

--- a/nginx.json
+++ b/nginx.json
@@ -1,6 +1,6 @@
 {
 	"nginx": {
-		"description": "Open source reverse proxy server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a web server.",
+		"description": "Open source web server for HTTP, HTTPS, SMTP, POP3, and IMAP protocols, as well as a load balancer, HTTP cache, and a reverse proxy server.<p>Advanced users only: You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>add a default config file to your "Config Storage" share.</a>.</p><p>Based on the official Nginx docker image: <a href='https://hub.docker.com/_/nginx' target='_blank'>https://hub.docker.com/_/nginx</a>.</p>",
 		"version": "1.0.0",
 		"website": "https://www.nginx.com/",
 		"icon": "https://cdn-1.wp.nginx.com/wp-content/themes/nginx-theme/assets/img/logo.svg",
@@ -28,7 +28,7 @@
 				},
 				"volumes": {
 					"/etc/nginx/conf.d": {
-						"description": "Choose a Share for the nginx configuration. Eg: create a Share called nginx-config for this purpose alone.<br/>You must <a href='https://gist.github.com/JasonTarka/63d632b5633fb0840cdfb3b56a14d388'>add a default config file</a>.",
+						"description": "Choose a Share for the nginx configuration. Eg: create a Share called nginx-config for this purpose alone.",
 						"label": "Config Storage",
 						"min_size": 10240
 					},


### PR DESCRIPTION
Use the official nginx image, but users will need to add a `default.conf` file to their nginx config share for the server to work. This is required as the mounted volume will shadow the `config` directory in the container that nginx tries to read the config file from.