### PR TITLE
Add netdata Rockon

### DIFF
--- a/netdata.json
+++ b/netdata.json
@@ -1,0 +1,40 @@
+{
+    "Netdata": {
+        "containers": {
+            "netdata": {
+                "image": "titpetric/netdata",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "--cap-add=SYS_PTRACE",
+                        ""
+                    ],
+                    [
+                        "-v",
+                        "/proc:/host/proc:ro"
+                    ],
+                    [
+                        "-v",
+                        "/sys:/host/sys:ro"
+                    ]
+                ],
+                "ports": {
+                    "19999": {
+                        "description": "port used to access the webUI port",
+                        "host_default": 19999,
+                        "label": "webUI port",
+                        "ui": true
+                    }
+                }
+            }
+        },
+        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p>",
+        "icon": "https://github.com/firehol/netdata/blob/master/web/images/seo-performance-64.png",
+        "more_info": "See https://github.com/firehol/netdata/wiki for more info.",
+        "website": "https://my-netdata.io/",
+        "ui": {
+            "slug": ""
+        },
+	    "version": "1.0"
+    }
+}

--- a/netdata.json
+++ b/netdata.json
@@ -33,6 +33,12 @@
                         "label": "webUI port",
                         "ui": true
                     }
+                },
+                "volumes": {
+                    "/etc/netdata/override": {
+                        "description": "Choose a Share for Netdata configuration files. All configuration files for custom plugins and alerts placed here will override defaults.",
+                        "label": "Config Storage"
+                    }
                 }
             }
         },

--- a/netdata.json
+++ b/netdata.json
@@ -10,6 +10,14 @@
                         ""
                     ],
                     [
+                        "--net=host",
+                        ""
+                    ],
+                    [
+                        "-v",
+                        "/var/run/docker.sock:/var/run/docker.sock"
+                    ],
+                    [
                         "-v",
                         "/proc:/host/proc:ro"
                     ],

--- a/root.json
+++ b/root.json
@@ -25,6 +25,7 @@
     "MariaDB": "mariadb.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",
+    "Netdata": "netdata.json",
     "NZBGet": "nzbget.json",
     "NZBHydra": "NZBHydra.json",
     "Ombi": "ombi.json",


### PR DESCRIPTION
Although Rockstor's dashboard provides a quick and instantaneous overview of most of the server's state, it could be limited for some users who would like to have a more detailed view of the machine's CPU, RAM, DISK, and NET usage.
Its documentation reads:

> netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS. It is open-source too.
> 
> Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core, even when it runs on IoT.

Notably, netdata allows the users to set specific alerts at custom thresholds, which could be of great interest for some. This would require, however, the user to mount an additional share and add email credentials that most users may not need/want to add. As a result, these may be better suited for use out of Rockons.

