### PR TITLE
Add koel Rock-on

### DIFF
--- a/koel.json
+++ b/koel.json
@@ -1,0 +1,70 @@
+{
+    "Koel": {
+        "containers": {
+            "koel": {
+                "image": "binhex/arch-koel",
+                "launch_order": 1,
+                "ports": {
+                    "8050": {
+                        "description": "Koel WebUI HTTP port. Suggested default: 8050",
+                        "host_default": 8050,
+                        "label": "WebUI port",
+                        "ui": true
+                    },
+                    "8060": {
+                        "description": "Koel HTTPS port. Suggested default: 8060",
+                        "host_default": 8060,
+                        "label": "HTTPs port",
+                        "ui": false
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for the Koel configuration. Eg: create a Share called koel-config for this purpose alone.",
+                        "label": "Config Storage"
+                    },
+                    "/media": {
+                        "description": "Choose a Share with media content. Eg: create a Share called koel-media for this purpose alone or use an existing share.",
+                        "label": "Media Storage"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid UID of an existing user with permission to media shares to run Koel as.",
+                        "label": "UID: ",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid GID of an exisiting user with permission to media shares to run Koel as.",
+                        "label": "GID: ",
+                        "index": 2
+                    },
+                    "PHP_MEMORY_LIMIT": {
+                        "description": "Memory limit. Default at 2048 (MB), but increase this value for large libraries.",
+                        "label": "Memory limit:",
+                        "index": 3
+                    },
+                    "FASTCGI_READ_TIMEOUT": {
+                        "description": "Timeout limit. Default at 6000 (sec), but increase this value for large libraries.",
+                        "label": "Timeout limit.",
+                        "index": 4
+                    },
+                    "UMASK": {
+                        "description": "UMASK for created files (000, for instance).",
+                        "label": "UMASK",
+                        "index": 5
+                    }
+                }
+            }
+        },
+        "description": "Koel music streaming server",
+        "more_info": "Koel is a simple web-based personal audio streaming service written in Vue on the client side and Laravel on the server side. Targeting web developers, Koel embraces some of the more modern web technologies – flexbox, audio, and drag-and-drop API to name a few – to do its job. <h4>Adding media to Koel.</h4><p>You can add Shares (with media) to Koel from the settings wizard of this Rock-on.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "website": "https://koel.phanan.net/",
+        "version": "1.0"
+    }
+}
+


### PR DESCRIPTION
Following forum user @OpenSourceUser 's request, this PR adds a Rock-on for the music streamer koel:
Website: https://koel.phanan.net
Docker hub image: https://hub.docker.com/r/binhex/arch-koel/

This image has been tested and verified to work by @OpenSourceUser. See following forum thread for reference:
https://forum.rockstor.com/t/adding-a-koel-rock-on/5240/8?u=flox

Ready for review.