### PR TITLE
Fix volume binding

### DIFF
--- a/cops.json
+++ b/cops.json
@@ -18,7 +18,7 @@
                         "description": "Choose a Share for cops configuration. Eg: create a Share called cops-config for this purpose alone.",
                         "label": "Config Storage"
                     },
-                    "/movies": {
+                    "/books": {
                         "description": "Choose a Share for cops book library. Eg: create a Share called cops-library for this purpose alone.",
                         "label": "Books location"
                     }


### PR DESCRIPTION
As discovered by @lgchris, the container requires a `/books` binding and not `/movies`. See the corresponding issue #165 for details.
Fixes #165 .