### PR TITLE
Add Bitwarden-rs alpine

### DIFF
--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -7,6 +7,7 @@
             "bitwarden-rs": {
                 "image": "mprasil/bitwarden",
                 "tag": "alpine",
+                "launch_order": 1,
                 "ports": {
                     "80": {
                         "description": "Admin interface",

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -9,7 +9,7 @@
                 "tag": "alpine",
                 "launch_order": 1,
                 "ports": {
-                    "80": {
+                    "443": {
                         "description": "Admin interface",
                         "label": "Admin interface",
                         "host_default": 80,
@@ -21,7 +21,14 @@
                     "/data": {
                         "description": "Where all bitwarden-rs data will be stored",
                         "label": "Bitwarden-rs storage"
+                    },
+                    "/ssl": {
+                        "description": "SSL cert/key location to enable ssl",
+                        "label": "Bitwarden-rs cert storage"
                     }
+                },
+                "environment": {
+                    "ROCKET_TLS": "{certs='/ssl/chain.pem',key='ssl/key.pem'}"
                 }
             }
         }

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -9,7 +9,7 @@
                 "tag": "alpine",
                 "launch_order": 1,
                 "ports": {
-                    "443": {
+                    "80": {
                         "description": "Admin interface",
                         "label": "Admin interface",
                         "host_default": 80,

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -1,0 +1,25 @@
+{
+    "Bitwarden-rs": {
+        "description": "Bitwarden-rs on Alpine",
+        "containers": {
+            "bitwarden-rs": {
+                "image": "mprasil/bitwarden",
+                "tag": "alpine",
+                "ports": {
+                    "80": {
+                        "description": "Admin interface",
+                        "label": "Admin interface",
+                        "host_default": 80,
+                        "protocol": "tcp"
+                    }
+                },
+                "volumes": {
+                    "/data": {
+                        "description": "Where all bitwarden-rs data will be stored",
+                        "label": "Bitwarden-rs storage"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -28,7 +28,7 @@
                     }
                 },
                 "opts": [
-                    ["-e", "ROCKET_TLS='{certs=\"/ssl/certs.pem\",key=\"/ssl/key.pem\"}'"]
+                    ["-e", "ROCKET_TLS={certs=\"/ssl/certs.pem\",key=\"/ssl/key.pem\"}"]
                 ]
             }
         }

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -27,9 +27,9 @@
                         "label": "Bitwarden-rs cert storage"
                     }
                 },
-                "environment": {
-                    "ROCKET_TLS": "{certs='/ssl/chain.pem',key='ssl/key.pem'}"
-                }
+                "opts": [
+                    ["-e", "ROCKET_TLS='{certs=\"/ssl/certs.pem\",key=\"/ssl/key.pem\"}'"]
+                ]
             }
         }
     }

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -1,6 +1,8 @@
 {
     "Bitwarden-rs": {
         "description": "Bitwarden-rs on Alpine",
+        "version": "0.0.1",
+        "website": "https://github.com/dani-garcia/bitwarden_rs",
         "containers": {
             "bitwarden-rs": {
                 "image": "mprasil/bitwarden",

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -13,7 +13,8 @@
                         "description": "Admin interface",
                         "label": "Admin interface",
                         "host_default": 80,
-                        "protocol": "tcp"
+                        "protocol": "tcp",
+                        "ui": true
                     }
                 },
                 "volumes": {

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -1,8 +1,13 @@
 {
     "Bitwarden-rs": {
-        "description": "Bitwarden-rs on Alpine",
+        "description": "Bitwarden password manager server in Rust.",
         "version": "0.0.1",
         "website": "https://github.com/dani-garcia/bitwarden_rs",
+        "more_info": "SSL/TLS certs and keys required. If you have a root/intermediate cert already, or you know how to set up Let's Encrypt and you're public facing, then you should be good to go. Otherwise, check out <a href=\"https://jamielinux.com/docs/openssl-certificate-authority/\">this link to learn how to be your own certificate authority</a>, or <a href=\"https://github.com/FiloSottile/mkcert\">the program mkcert to deal with less commands.</a>",
+        "ui": {
+            "https": true,
+            "slug": ""
+        },
         "containers": {
             "bitwarden-rs": {
                 "image": "mprasil/bitwarden",

--- a/root.json
+++ b/root.json
@@ -1,6 +1,7 @@
 {
     "Bitcoin": "bitcoind.json",
     "Booksonic": "booksonic.json",
+    "Bitwarden-rs": "bitwarden-rs-alpine.json",
     "BTSync": "btsync.json",
     "COPS": "cops.json",
     "Collabora Online": "collabora-online.json",


### PR DESCRIPTION
Rockon for [this unofficial bitwarden docker image](https://github.com/dani-garcia/bitwarden_rs)

Written in rust, uses less resources than the official image, and the image runs on Alpine, so it's even *smaller*.

Some setup required:
* TLS/SSL certs + key: full chain cert must be at `/ssl/certs.pem` and key at `/ssl/key.pem` (I made this share first, turned it into an SMB share, placed the files in, then pointed the Rockon at the share, but as long as the files exist in the right spot you're good to go)

Container port 80 mapped out to whatever, default doesn't really matter so feel free to change it to whatever doesn't clash with existing systems.

Confirmed working on Rockstor 3.9.1-16, Bitwarden 2.8.0 (docker tag 1.5.0-alpine or something close to that), Chrome extension 1.37.0, and Android app 1.21.0 (but should work with all versions)