### PR TITLE
Issue166 ts3 official

### DIFF
--- a/teamspeak3.json
+++ b/teamspeak3.json
@@ -1,7 +1,7 @@
 {
-    "Teamspeak3 Official": {
+    "Teamspeak3": {
         "containers": {
-            "Teamspeak3_official": {
+            "Teamspeak3": {
                 "image": "teamspeak",
                 "launch_order": 1,
                 "ports": {
@@ -42,10 +42,10 @@
                 }
             }
         },
-        "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.",
+        "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.<p>Based on the official Teamspeak docker image: <a href='https://hub.docker.com/_/teamspeak' target='_blank'>https://hub.docker.com/_/teamspeak</a>.",
     	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3_official | grep loginname</p><br><p>If it's the second or more start of this Rock-on, please use the following instead:</p> docker exec Teamspeak3_official sh -c 'cat logs/*.log | grep token'</p>",
         "volume_add_support": false,
-	    "website": "https://hub.docker.com/_/teamspeak",
+	    "website": "https://teamspeak.com/en/",
 	    "version": "2.0"
     }
 }

--- a/teamspeak3.json
+++ b/teamspeak3.json
@@ -43,7 +43,7 @@
             }
         },
         "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.<p>Based on the official Teamspeak docker image: <a href='https://hub.docker.com/_/teamspeak' target='_blank'>https://hub.docker.com/_/teamspeak</a>.",
-    	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3_official | grep loginname</p><br><p>If it's the second or more start of this Rock-on, please use the following instead:</p> docker exec Teamspeak3_official sh -c 'cat logs/*.log | grep token'</p>",
+    	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3 | grep loginname</p><br><p>If it's the second or more start of this Rock-on, please use the following instead:</p> docker exec Teamspeak3 sh -c 'cat logs/*.log | grep token'</p>",
         "volume_add_support": false,
 	    "website": "https://teamspeak.com/en/",
 	    "version": "2.0"

--- a/teamspeak3.json
+++ b/teamspeak3.json
@@ -1,8 +1,8 @@
 {
-    "Teamspeak3": {
+    "Teamspeak3 Official": {
         "containers": {
-            "Teamspeak3": {
-                "image": "linuxserver/gsm-ts3",
+            "Teamspeak3_official": {
+                "image": "teamspeak",
                 "launch_order": 1,
                 "ports": {
                     "9987": {
@@ -28,29 +28,24 @@
                     }
                 },
                 "volumes": {
-                    "/config": {
-                        "description": "Choose a Share for Teamspeak3 configuration. Eg: create a Share called Teamspeak3-config for this purpose alone.",
+                    "/var/ts3server/": {
+                        "description": "Choose a Share for Teamspeak3 data. Eg: create a Share called Teamspeak3-data for this purpose alone.",
                         "label": "Config Storage"
                     }
                 },
                 "environment": {
-                    "PUID": {
-		        "description": "Enter a valid UID to run Teamspeak3 as. It must have full permissions to all Shares mapped in the previous step.",
-                        "label": "UID to run Teamspeak3 as.",
+                    "TS3SERVER_LICENSE": {
+		        "description": "To run TeamSpeak, you must accept its license. Enter `accept` if you do.",
+                        "label": "Accept license?",
                         "index": 1
-		    },
-                    "PGID": {
-                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
-                        "label": "GID to run Teamspeak3 as.",
-                        "index": 2
                     }
                 }
             }
         },
         "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.",
-    	    "more_info": "<h4>You need to get the previliged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. cd /mnt2/[sharename]/serverfiles/logs</p>3. grep \"token\" ./*",
+    	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3_official | grep loginname",
         "volume_add_support": false,
-	"website": "https://hub.docker.com/r/linuxserver/gsm-ts3/",
-	"version": "1.0"
+	    "website": "https://hub.docker.com/_/teamspeak",
+	    "version": "2.0"
     }
 }

--- a/teamspeak3.json
+++ b/teamspeak3.json
@@ -43,7 +43,7 @@
             }
         },
         "description": "VoIP software designed with security in mind, featuring crystal clear voice quality, endless customization options, and scalabilty up to thousands of simultaneous users.",
-    	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3_official | grep loginname",
+    	"more_info": "<h4>You need to get the privileged key using system console to get serveradmin access</h4></p>1. Open system console (don't forget to start the service) or use SSH</p>2. docker logs Teamspeak3_official | grep loginname</p><br><p>If it's the second or more start of this Rock-on, please use the following instead:</p> docker exec Teamspeak3_official sh -c 'cat logs/*.log | grep token'</p>",
         "volume_add_support": false,
 	    "website": "https://hub.docker.com/_/teamspeak",
 	    "version": "2.0"


### PR DESCRIPTION
Fix #166 

This PR updates the Teamspeak3 Rock-on to use the official docker image: [https://hub.docker.com/_/teamspeak](https://hub.docker.com/_/teamspeak)

This change is currently **required** as the current image has already been deprecated. See Issue #166 for details and discussion on naming convention.

This has been tested to work on Rockstor-3.9.1-16 by myself and confirmed by the issue author @Noggin01.

@phillxnet, this PR is ready for your attention.