### PR TITLE
use new official jenkins image. Fixes #177

### DIFF
--- a/jenkins.json
+++ b/jenkins.json
@@ -1,38 +1,41 @@
 {
     "JenkinsCI": {
-	"description": "Leading open source automation server",
-	"ui": {
-	    "slug": ""
-	},
-	"website": "https://jenkins-ci.org/",
-	"version": "1.0",
-	"containers": {
-	    "jenkins": {
-		"image": "jenkins",
-		"launch_order": 1,
-		"uid": -1,
-		"ports": {
-		    "8080": {
-			"description": "Jenkins UI port. You may need to open it(protocol: tcp) on your firewall.",
-			"host_default": 8080,
-			"label": "Server port",
-			"protocol": "tcp",
-			"ui": true
-		    },
-		    "50000": {
-			"description": "Slave agent port.",
-			"host_default": 50000,
-			"label": "Agent port",
-			"protocol": "tcp"
-		    }
-		},
-		"volumes": {
-		    "/var/jenkins_home": {
-			"description": "Choose a Share for Jenkins home. Jenkins will run as the same user that owns this Share. It is recommended to set the owner to a non-root user",
-			"label": "Jenkins Home"
-		    }
-		}
-	    }
-	}
+        "description": "Jenkins is an open source automation server. Reliably build, test, and deploy software.<p>Uses official LTS docker image: <a href='https://hub.docker.com/r/jenkins/jenkins' target='_blank'>https://hub.docker.com/r/jenkins/jenkins</a>",
+        "more_info": "Initial Web-UI visit gives location of admin password within the chosen share.<p>Click spanner icon for share name and associated mapping.<p>Note: potential Firefox incompatibility (Blank Web-UI) post initial setup.<p>Note: if 'Save and Continue' while creating first admin user fails, skip using 'Continue as admin'.",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://jenkins.io/",
+        "icon": "http://ftp-nyc.osuosl.org/pub/jenkins/art/jenkins-logo/128x128/logo.png",
+        "version": "2.0",
+        "containers": {
+            "jenkins": {
+                "image": "jenkins/jenkins",
+                "tag": "lts",
+                "launch_order": 1,
+                "uid": -1,
+                "ports": {
+                    "8080": {
+                        "description": "Jenkins UI port (default 8080). You may need to open this port (protocol: tcp) on your firewall if remote access is required.",
+                        "host_default": 8080,
+                        "label": "Server port",
+                        "protocol": "tcp",
+                        "ui": true
+                    },
+                    "50000": {
+                        "description": "JNLP (Jave Web Start) Build executors port (default 50000) for slave agents not using SSH.",
+                        "host_default": 50000,
+                        "label": "Agent port",
+                        "protocol": "tcp"
+                    }
+                },
+                "volumes": {
+                    "/var/jenkins_home": {
+                        "description": "Choose a share for Jenkins home, e.g named 'jenkins_home', solely for this purpose. Jenkins will run as the same user that owns this share. It is recommended to set the owner to a non-root user",
+                        "label": "Jenkins Home"
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Text and image update of existing Jenkins CI Rockon. See issue #177 for context.

Summary of changes
- update image
- spaces not tabs
- Improve description, adding docker image reference

Fixes #177 

Ready for review.

Caveat:
This Rock-on's user facing text states/assumes its use of the LTS variant docker image. However we have an outstanding rockstor-core issue (with pending pr fix) that this Rockon depends upon.

Prior to review dependencies:

Issue:
"honour tag element within rock-on json #2014"
https://github.com/rockstor/rockstor-core/issues/2014

Pull request currently pending:
"honour tag element within rock-on json. Fixes #2014"
https://github.com/rockstor/rockstor-core/pull/2016