### PR TITLE
updated unifi-linuxserver

### DIFF
--- a/unifi-linuxserver.json
+++ b/unifi-linuxserver.json
@@ -2,7 +2,7 @@
     "Ubiquiti Unifi linuxserver.io": {
         "containers": {
             "unifi-linuxserver": {
-                "image": "linuxserver/unifi",
+                "image": "linuxserver/unifi-controller",
                 "launch_order": 1,
                 "ports": {
                     "3478": {
@@ -83,13 +83,13 @@
             }
         },
         "description": "Unifi Access Point controller",
-        "more_info": "This is a containerized version of Ubiquiti Networks Unifi Controller.",
+        "more_info": "This is a containerized version of Ubiquiti Networks Unifi Controller. To limit memory add MEM_LIMIT=1024M as a custom argument after install",
         "volume_add_support": false,
         "ui": {
             "https": true,
             "slug": ""
         },
-        "website": "https://hub.docker.com/r/linuxserver/unifi/",
-        "version": "1.0"
+        "website": "https://hub.docker.com/r/linuxserver/unifi-controller/",
+        "version": "1.1"
     }
 }

--- a/unifi-linuxserver.json
+++ b/unifi-linuxserver.json
@@ -82,7 +82,7 @@
                 }
             }
         },
-        "description": "Unifi Access Point controller",
+        "description": "Unifi Access Point controller. <p>Based on the LinuxServer.io Unifi-controller docker image: <a href='https://hub.docker.com/r/linuxserver/unifi-controller' target='_blank'>https://hub.docker.com/r/linuxserver/unifi-controller</a>.",
         "more_info": "This is a containerized version of Ubiquiti Networks Unifi Controller. To limit memory add MEM_LIMIT=1024M as a custom argument after install",
         "volume_add_support": false,
         "ui": {

--- a/unifi-linuxserver.json
+++ b/unifi-linuxserver.json
@@ -1,7 +1,7 @@
 {
     "Ubiquiti Unifi linuxserver.io": {
         "containers": {
-            "unifi-linuxserver": {
+            "unifi-linuxserver.io": {
                 "image": "linuxserver/unifi-controller",
                 "launch_order": 1,
                 "ports": {

--- a/unifi-linuxserver.json
+++ b/unifi-linuxserver.json
@@ -89,7 +89,7 @@
             "https": true,
             "slug": ""
         },
-        "website": "https://hub.docker.com/r/linuxserver/unifi-controller/",
+        "website": "https://www.ubnt.com/enterprise/#unifi",
         "version": "1.1"
     }
 }


### PR DESCRIPTION
Updated repo to point to new linuxserver unfi-controller repo since the unifi repo is depracted.  The version is already out of support.  The new repo is under support and has no impact on an existing installation.  It is also recommended by unifi as the preferred docker method.  We also have an option for an extra argument to cap memory but I put that in the more_info section rather than forcing the user to enter it.  This is for https://github.com/rockstor/rockon-registry/issues/191