### PR TITLE
Change deluge to --net=host to allow remote connec

### DIFF
--- a/deluge.json
+++ b/deluge.json
@@ -18,8 +18,15 @@
                         "label": "Daemon port",
                         "protocol": "tcp",
                         "ui": true
+                    },
+                    "58946": {
+                        "description": "Deluge Remote connection port. Suggested default: 58946",
+                        "host_default": 58946,
+                        "label": "Remote connection port",
+                        "ui": true
                     }
                 },
+                "opts": ["--net", "host"],
                 "volumes": {
                     "/config": {
                         "description": "Choose a Share for Deluge configuration. Eg: create a Share called Deluge-config for this purpose alone.",


### PR DESCRIPTION
As per https://github.com/linuxserver/docker-deluge/blob/master/Dockerfile the port 58946 should be exposed.
And for remote connections while seeding to actually be possible, the network mode needs to be 'host' (see https://github.com/linuxserver/docker-deluge#parameters )