### PR TITLE
Update Plex Rock-On to allow optional support of Intel QuickSync transcoding

### DIFF
--- a/plex.json
+++ b/plex.json
@@ -1,7 +1,7 @@
 {
-  "Plex-QuickSync": {
+  "Plex": {
     "containers": {
-      "plex-linuxserver.io-qs": {
+      "plex-linuxserver.io": {
         "image": "linuxserver/plex",
         "opts": [
           [

--- a/plex.json
+++ b/plex.json
@@ -33,7 +33,6 @@
             "description": "Choose a Share for Plex content (your media). E.g.: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation. This share needs to have at least Read/Execute access for the user and group specified later",
             "label": "Data Storage"
           }
-   
         },
         "environment": {
           "VERSION": {

--- a/plex.json
+++ b/plex.json
@@ -12,7 +12,7 @@
         "launch_order": 1,
         "devices": {
           "/dev/dri": {
-            "description": "optional: Device Path for enabling Intel QuickSync (check CPU documentation at at ark.intel.com for availability) (/dev/dri). Leave blank if not needed.",
+            "description": "optional device path for enabling Intel QuickSync (example: /dev/dri). Leave blank if not needed. Check CPU documentation at ark.intel.com to check for QuickSync support.",
             "label": "QuickSync device"
           }
         },

--- a/plex.json
+++ b/plex.json
@@ -53,13 +53,13 @@
         }
       }
     },
-    "description": "Plex media server by Linuxserver.io - with added (optional) Intel QuickSync hardware transcoding (check your processor's documentation).",
-    "more_info": "<h4>Adding more media to Plex.</h4><p>You can add more Shares later to Plex from the settings wizard of this Rock-on. If you have maintained a QuickSync Device during the initial setup, you need to add a transcoding share (preferrably on an SSD). Then, from Plex WebUI, you can update the transcode directory setting and for new media shares re-index your library. Visit https://hub.docker.com/r/linuxserver/plex for a description of each option.</p>",
+    "description": "Organize and stream your personal media collection of movies, TV, music, and photos anywhere on all your devices. This rock-on supports hardware transcoding (optional) via Intel QuickSync -- see <a href='https://ark.intel.com/content/www/us/en/ark/search/featurefilter.html?productType=873&0_QuickSyncVideo=True' target='_blank'>Intel ark</a> to check your processor's compatibility.<p>Additional <a href='http://rockstor.com/docs/docker-based-rock-ons/plex-media-server.html#plex-server-rock-on' target='_blank'>documentation</a> is available for this rock-on.</p><p>Based on the docker image provided by Linuxserver.io: <a href='https://hub.docker.com/r/linuxserver/plex/' target='_blank'>https://hub.docker.com/r/linuxserver/plex/</a>.</p>",
+    "more_info": "<h4>Adding more media to Plex</h4><p>First, add the share(s) containing your additional media to this rock-on using its settings wizard. Then, from Plex webUI, you can add this/these share(s) and re-index your library. See <a href='http://rockstor.com/docs/docker-based-rock-ons/plex-media-server.html#adding-shares-to-plex' target='_blank'>Rockstor's documentation</a> for detailed instructions.</p> <h4>Hardware transcoding using Intel QuickSync</h4>If you have a compatible processor and filled the <em>QuickSync device</em> field during the rock-on installation, please note that you also need to add a dedicated share (named <em>plex-transcoding</em>, for instance) mapped as <code>/transcode</code> that will be used for transcoding only. Then, from Plex WebUI, you can update the <strong>transcode</strong> directory setting.</p>",
     "ui": {
       "slug": "web"
     },
     "volume_add_support": true,
-    "website": "https://hub.docker.com/r/linuxserver/plex/",
+    "website": "https://www.plex.tv",
     "version": "1.0"
   }
 }

--- a/plex.json
+++ b/plex.json
@@ -32,12 +32,8 @@
           "/data": {
             "description": "Choose a Share for Plex content(your media). E.g.: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation. This share needs to at least have Read/Execute access for the User group specified later",
             "label": "Data Storage"
-          },
-          "/transcode": {
-            "description": "Especially for QuickSync, choose a share for HW transcoding. E.g.: create a Share called transcode for this purpose alone (ideally on an SSD). It is important that the owner/group specified later have full access to the share (R/W/E)",
-            "label": "Transcoding Directory"
           }
-
+   
         },
         "environment": {
           "VERSION": {
@@ -59,7 +55,7 @@
       }
     },
     "description": "Plex media server by Linuxserver.io - with added (optional) Intel QuickSync hardware transcoding (check your processor's documentation).",
-    "more_info": "<h4>Adding more media to Plex.</h4><p>You can add more Shares(with media) to Plex from the settings wizard of this Rock-on. Then, from Plex WebUI, you can update and re-index your library. Visit https://hub.docker.com/r/linuxserver/plex for a description of each option.</p>",
+    "more_info": "<h4>Adding more media to Plex.</h4><p>You can add more Shares later to Plex from the settings wizard of this Rock-on. If you have maintained a QuickSync Device during the initial setup, you need to add a transcoding share (preferrably on an SSD). Then, from Plex WebUI, you can update the transcode directory setting and for new media shares re-index your library. Visit https://hub.docker.com/r/linuxserver/plex for a description of each option.</p>",
     "ui": {
       "slug": "web"
     },

--- a/plex.json
+++ b/plex.json
@@ -1,59 +1,70 @@
 {
-    "Plex": {
-        "containers": {
-            "plex-linuxserver.io": {
-                "image": "linuxserver/plex",
-                "opts": [
-                    [
-                        "--net=host",
-                        ""
-                    ]
-                ],
-                "launch_order": 1,
-                "ports": {
-                    "32400": {
-                        "description": "WebUI port. Suggested default: 32400",
-                        "host_default": 32400,
-                        "label": "WebUI port",
-                        "ui": true
-                    }
-                },
-                "volumes": {
-                    "/config": {
-                        "description": "Choose a Share for Plex configuration. Eg: create a Share called plex-config for this purpose alone.",
-                        "label": "Config Storage"
-                    },
-                    "/data": {
-                        "description": "Choose a Share for Plex content(your media). Eg: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation.",
-                        "label": "Data Storage"
-                    }
-                },
-                "environment": {
-                    "VERSION": {
-                        "description": "Choose version of plex. unless you know which version to try, just type latest",
-                        "label": "VERSION",
-                        "index": 1
-                    },
-                    "PUID": {
-                        "description": "Enter a valid UID to run Plex with. It must have full permissions to all Shares mapped in the previous step.",
-                        "label": "UID",
-                        "index": 2
-                    },
-                    "PGID": {
-                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
-                        "label": "GID",
-                        "index": 3
-                    }
-                }
-            }
+  "Plex-QuickSync": {
+    "containers": {
+      "plex-linuxserver.io-qs": {
+        "image": "linuxserver/plex",
+        "opts": [
+          [
+            "--net=host",
+            ""
+          ]
+        ],
+        "launch_order": 1,
+        "devices": {
+          "dev/dri": {
+            "description": "optional: Device Path for enabling Intel QuickSync (check CPU documentation at at ark.intel.com for availability) (/dev/dri). Leave blank if not needed.",
+            "label": "QuickSync device"
+          }
         },
-        "description": "Plex media server by Linuxserver.io",
-        "more_info": "<h4>Adding more media to Plex.</h4><p>You can add more Shares(with media) to Plex from the settings wizard of this Rock-on. Then, from Plex WebUI, you can update and re-index your library.</p>",
-        "ui": {
-            "slug": "web"
+        "ports": {
+          "32400": {
+            "description": "WebUI port. Suggested default: 32400",
+            "host_default": 32400,
+            "label": "WebUI port",
+            "ui": true
+          }
         },
-        "volume_add_support": true,
-        "website": "https://hub.docker.com/r/linuxserver/plex/",
-        "version": "1.0"
-    }
+        "volumes": {
+          "/config": {
+            "description": "Choose a Share for Plex configuration. E.g.: create a Share called plex-config for this purpose alone. It is important that the owner/group specified later have full access to the share (R/W/E)",
+            "label": "Config Storage"
+          },
+          "/data": {
+            "description": "Choose a Share for Plex content(your media). E.g.: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation. This share needs to at least have Read/Execute access for the User group specified later",
+            "label": "Data Storage"
+          },
+          "/transcode": {
+            "description": "Especially for QuickSync, choose a share for HW transcoding. E.g.: create a Share called transcode for this purpose alone (ideally on an SSD). It is important that the owner/group specified later have full access to the share (R/W/E)",
+            "label": "Transcoding Directory"
+          }
+
+        },
+        "environment": {
+          "VERSION": {
+            "description": "Choose version of plex: Unless you know which version to try, just type latest",
+            "label": "VERSION",
+            "index": 1
+          },
+          "PUID": {
+            "description": "Enter a valid UID to run Plex with. It must have full permissions to all Shares mapped in the previous step.",
+            "label": "UID",
+            "index": 2
+          },
+          "PGID": {
+            "description": "Enter a valid GID to use along with the above UID. It (or the above UID) must have full permissions to all Shares mapped in the previous step.",
+            "label": "GID",
+            "index": 3
+          }
+        }
+      }
+    },
+    "description": "Plex media server by Linuxserver.io - with added (optional) Intel QuickSync hardware transcoding (check your processor's documentation).",
+    "more_info": "<h4>Adding more media to Plex.</h4><p>You can add more Shares(with media) to Plex from the settings wizard of this Rock-on. Then, from Plex WebUI, you can update and re-index your library. Visit https://hub.docker.com/r/linuxserver/plex for a description of each option.</p>",
+    "ui": {
+      "slug": "web"
+    },
+    "volume_add_support": true,
+    "website": "https://hub.docker.com/r/linuxserver/plex/",
+    "version": "1.0"
+  }
 }

--- a/plex.json
+++ b/plex.json
@@ -11,7 +11,7 @@
         ],
         "launch_order": 1,
         "devices": {
-          "dev/dri": {
+          "/dev/dri": {
             "description": "optional: Device Path for enabling Intel QuickSync (check CPU documentation at at ark.intel.com for availability) (/dev/dri). Leave blank if not needed.",
             "label": "QuickSync device"
           }

--- a/plex.json
+++ b/plex.json
@@ -30,7 +30,7 @@
             "label": "Config Storage"
           },
           "/data": {
-            "description": "Choose a Share for Plex content(your media). E.g.: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation. This share needs to at least have Read/Execute access for the User group specified later",
+            "description": "Choose a Share for Plex content (your media). E.g.: create a Share called plex-data for this purpose alone. You can also assign other media Shares on the system after installation. This share needs to have at least Read/Execute access for the user and group specified later",
             "label": "Data Storage"
           }
    


### PR DESCRIPTION
Merge updates

> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes # .
Add QuickSync option (device) to enable Intel HW transcoding

### General information on project
This pull request proposes to enhance an existing rock-on for the following project:
- name: Plex Rockon
- website: N/A
- description: using existing Plex RockOn definition under underlying Docker Image from linuxserver.io add option to enable QuickSync certain Intel CPUs.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/plex
- is an official docker image available for this project?: yes, but since this is an enhancement to the existing RockOn, continuing to use the Linuxserver.io maintained docker (which is actively updated in line with official Plex releases).


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- N/A Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
