### PR TITLE
Bitwarden rs alpine

### DIFF
--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -1,6 +1,6 @@
 {
     "Bitwarden-rs": {
-        "description": "Bitwarden password manager server in Rust.",
+        "description": "Bitwarden password manager server in Rust and on Alpine (speed, size). Uses <a href=\"https://hub.docker.com/r/bitwardenrs/server\">bitwardenrs/server</a>.",
         "version": "0.0.1",
         "website": "https://github.com/dani-garcia/bitwarden_rs",
         "more_info": "SSL/TLS certs and keys required. They go in /ssl/certs.pem and /ssl/key.pem, respectively. certs.pem can be a chain. Need a cert? Try mkcert or openssl.",

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -3,14 +3,14 @@
         "description": "Bitwarden password manager server in Rust.",
         "version": "0.0.1",
         "website": "https://github.com/dani-garcia/bitwarden_rs",
-        "more_info": "SSL/TLS certs and keys required. If you have a root/intermediate cert already, or you know how to set up Let's Encrypt and you're public facing, then you should be good to go. Otherwise, check out <a href=\"https://jamielinux.com/docs/openssl-certificate-authority/\">this link to learn how to be your own certificate authority</a>, or <a href=\"https://github.com/FiloSottile/mkcert\">the program mkcert to deal with less commands.</a>",
+        "more_info": "SSL/TLS certs and keys required. They go in /ssl/certs.pem and /ssl/key.pem, respectively. certs.pem can be a chain. Need a cert? Try mkcert or openssl.",
         "ui": {
             "https": true,
             "slug": ""
         },
         "containers": {
             "bitwarden-rs": {
-                "image": "mprasil/bitwarden",
+                "image": "bitwardenrs/server",
                 "tag": "alpine",
                 "launch_order": 1,
                 "ports": {

--- a/bitwarden-rs-alpine.json
+++ b/bitwarden-rs-alpine.json
@@ -1,9 +1,9 @@
 {
     "Bitwarden-rs": {
-        "description": "Bitwarden password manager server in Rust and on Alpine (speed, size). Uses <a href=\"https://hub.docker.com/r/bitwardenrs/server\">bitwardenrs/server</a>.",
+        "description": "Bitwarden password manager server in Rust and on Alpine (speed, size). <p>Based on the following docker image: <a href='https://hub.docker.com/r/bitwardenrs/server' target='_blank'>https://hub.docker.com/r/bitwardenrs/server</a></p>.",
         "version": "0.0.1",
         "website": "https://github.com/dani-garcia/bitwarden_rs",
-        "more_info": "SSL/TLS certs and keys required. They go in /ssl/certs.pem and /ssl/key.pem, respectively. certs.pem can be a chain. Need a cert? Try mkcert or openssl.",
+        "more_info": "SSL/TLS certs and keys required. They must be placed in the Rockstor share used as <em>Bitwarden-rs cert storage</em> during the rock-on's installation process:<br><ul><li><code>/mnt2/[share-name]/certs.pem</code></li><li><code>/mnt2/[share-name]/key.pem</code></li></ul><br>Of note, <code>certs.pem</code> can be a chain. Need a cert? Try <a href=\"https://github.com/FiloSottile/mkcert\" target=\"_blank\">mkcert</a> or openssl.",
         "ui": {
             "https": true,
             "slug": ""


### PR DESCRIPTION
Fixes #208.

### General information on project
This pull request proposes to update a rock-on for the following project:
- name: bitwarden-rs
- website: https://github.com/dani-garcia/bitwarden_rs
- description: Bitwarden password manager server in Rust.

### Information on docker image
- docker image: https://hub.docker.com/r/bitwardenrs/server
- is an official docker image available for this project?: yes, but this one is smaller and self-contained (for reference, the original looks like it's [spread out over 6 containers](https://help.bitwarden.com/images/hosting/docker-ps.png))

### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
