### PR TITLE
Update HandBrake rock-on device description, Fixes #212:

### DIFF
--- a/handbrake.json
+++ b/handbrake.json
@@ -5,9 +5,9 @@
                 "image": "jlesage/handbrake",
                 "launch_order": 1,
                 "devices": {
-                    "VAAPI": {
-                        "description": "<u>Optional:</u> path to hardware transcoding device (/dev/dri/renderD128). Leave blank if not needed.",
-                        "label": "VAAPI device"
+                    "quicksync": {
+                        "description": "Optional: path to hardware transcoding device for Intel Quick Sync (/dev/dri). Leave blank if not needed.",
+                        "label": "Intel Quick Sync device"
                     }
                 },
                 "ports": {
@@ -59,7 +59,7 @@
         },
         "description": "Handbrake for converting video from nearly any format to a selection of modern, widely supported codecs. <p>This docker image makes HandBrake accessible through your browser (<em>HandBrake UI</em> button) or VNC, see <em>more info</em> for details.</p><p>Based on the jlesage/handbrake docker image: <a href='https://hub.docker.com/r/jlesage/handbrake' target='_blank'>https://hub.docker.com/r/jlesage/handbrake</a>.</p>",
         "icon": "https://upload.wikimedia.org/wikipedia/commons/d/d9/HandBrake_Icon.png",
-        "more_info": "<p>Additional volumes can be added to provide extra watch folders.</p><p>Documentation on how to access using VNC and adding security can be found here <a href='https://github.com/jlesage/docker-handbrake#accessing-the-gui' target='_blank'>jlesage/docker-handbrake</a>, configuring extra volumes/watch folders can be found here <a href='http://rockstor.com/docs/docker-based-rock-ons/overview.html#add-storage' target='_blank'>Rock-ons Documentation</a></p>",
+        "more_info": "<p>Additional volumes can be added to provide extra watch folders (see <a href='http://rockstor.com/docs/docker-based-rock-ons/overview.html#add-storage' target='_blank'>Rockstor's documentation</a>).</p><p>Documentation on how to access using VNC and adding security can be found here: <a href='https://github.com/jlesage/docker-handbrake#accessing-the-gui' target='_blank'>jlesage/docker-handbrake</a>.</p>",
         "ui": {
             "slug": ""
         },


### PR DESCRIPTION
Fixes #212 .

### General information on project
This pull request proposes to update an existing rock-on for the following project:
- name: HandBrake
- website: [https://handbrake.fr](https://handbrake.fr)
- description: video transcoding with included GUI

### Information on docker image
- docker image: [https://hub.docker.com/r/jlesage/handbrake](https://hub.docker.com/r/jlesage/handbrake
- is an official docker image available for this project?: N/A

### Summary of changes
- remove unsupported <u> html tags
- replace mentions of VAAPI with Intel Quick Sync
- replace example device path to the Interl Quick Sync one
- minor edit of "more_info" field

### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website

@phillxnet , @mikey0000 , ready for review.
