### PR TITLE
Issue216 PostgreSQL 9.5 rockon

### DIFF
--- a/postgres-9.5.json
+++ b/postgres-9.5.json
@@ -1,5 +1,5 @@
 {
-  "PostgreSQL": {
+  "PostgreSQL 9.5": {
     "description": "PostgreSQL (9.5.21), open-source relational DBMS.<p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.</p><p><strong>Note: </strong>This rock-on requires Rockstor version 3.9.2-53 or later.</p>",
     "version":"1.2",
     "website":"https://www.postgresql.org",

--- a/postgres-9.5.json
+++ b/postgres-9.5.json
@@ -1,0 +1,41 @@
+{
+  "PostgreSQL": {
+    "description": "PostgreSQL (9.5.21), open-source relational DBMS.<p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.</p><p><strong>Note: </strong>Note: This rock-on requires Rockstor version 3.9.2-53 or later.</p>",
+    "version":"1.2",
+    "website":"https://www.postgresql.org",
+    "more_info": "<h4>Important locations inside docker image:</h4><p>Config. file:<code>/var/lib/pgsql/data/pg_hba.conf</code></p> <p>Databases: <code>/var/lib/pgsql/data</code></p> <p>Logs: <code>/var/log/postgresql</code></p>",
+    "volume_add_support":true,
+    "containers": {
+        "postgresql": {
+        "image": "postgres",
+        "launch_order":1,
+        "tag": "9.5.21",
+        "ports": {
+            "5432": {
+                "description":"PostgreSQL port. Suggested default: 5433 (Rockstor typically uses 5432 already)",
+                "host_default":5433,
+                "label":"PostgreSQL port",
+                "protocol":"tcp"
+            }
+        },
+        "volumes": {
+            "/var/lib/postgresql/data":{
+                "description":"Choose a share where the database should be stored. E.g.: create a share called postgresql-share1 for this purpose alone.",
+                "label":"Data Storage"
+            }
+        },
+        "environment": {
+            "POSTGRES_USER": {
+                "description": "Choose A Super User name for the PostgreSQL installation",
+                "label": "SuperUser"
+            },
+            "POSTGRES_PASSWORD": {
+                "description": "set a password for the Super User.",
+                "label": "SuperUser password"
+            }
+        }
+        }
+     }
+
+   }
+}

--- a/postgres-9.5.json
+++ b/postgres-9.5.json
@@ -20,7 +20,7 @@
         },
         "volumes": {
             "/var/lib/postgresql/data":{
-                "description":"Choose a share where the database should be stored. E.g.: create a share called postgresql-share1 for this purpose alone.",
+                "description":"Choose a share where the database should be stored. E.g.: create a share called postgresql95-data for this purpose alone.",
                 "label":"Data Storage"
             }
         },

--- a/postgres-9.5.json
+++ b/postgres-9.5.json
@@ -1,6 +1,6 @@
 {
   "PostgreSQL": {
-    "description": "PostgreSQL (9.5.21), open-source relational DBMS.<p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.</p><p><strong>Note: </strong>Note: This rock-on requires Rockstor version 3.9.2-53 or later.</p>",
+    "description": "PostgreSQL (9.5.21), open-source relational DBMS.<p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.</p><p><strong>Note: </strong>This rock-on requires Rockstor version 3.9.2-53 or later.</p>",
     "version":"1.2",
     "website":"https://www.postgresql.org",
     "more_info": "<h4>Important locations inside docker image:</h4><p>Config. file:<code>/var/lib/pgsql/data/pg_hba.conf</code></p> <p>Databases: <code>/var/lib/pgsql/data</code></p> <p>Logs: <code>/var/log/postgresql</code></p>",

--- a/root.json
+++ b/root.json
@@ -50,6 +50,7 @@
     "Plex": "plex.json",
     "Plexpy": "plexpy.json",
     "PocketMine": "pocketmine.json",
+    "PostgreSQL 9.5": "postgres-9.5.json",
     "Radarr": "radarr.json",
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",


### PR DESCRIPTION
Net New.

Fixes #216 

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: PostgreSQL 9.5 (using official docker container)
- website: postgresql.org
- description: allow installation of PostgreSQL 9.5(.21) as a rockon, so it can be used by other applications that require a RDBMS.

### Information on docker image
- docker image: https://hub.docker.com/_/postgres
- is an official docker image available for this project?: yes, this is the official docker image


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
