### PR TITLE
add new Folding@home Rock-on using the linuxserver.io docker image. Fixes #219

### DIFF
--- a/foldingathome-linuxserver.json
+++ b/foldingathome-linuxserver.json
@@ -1,0 +1,56 @@
+{
+    "Folding@home Linuxserver.io": {
+        "version": "1.0",
+        "description": "Folding@home (FAH or F@h) is a distributed computing project for simulating protein dynamics. Be One in a Million: every little helps.<p>Based on the latest Linuxserver.io docker image: <a href='https://hub.docker.com/r/linuxserver/foldingathome' target='_blank'>https://hub.docker.com/r/linuxserver/foldingathome</a>.",
+        "more_info": "<h4>Installation notes</h4><p>This Rock-on is CPU only by default. GPU folding capability requires: Rockstor4 or above (docker 19.03+) with Nvidia drivers & nvidia-docker installed (untested). See <a href='https://github.com/NVIDIA/nvidia-docker' target='_blank'>https://github.com/NVIDIA/nvidia-docker</a></p><p><i>It may take a few minutes for your instance to begin contributing, & a few more for the details of the project to appear. </i><br>After Rock-on install no further configuration is required for normal function.</p>",
+        "website": "https://foldingathome.org/",
+        "icon": "",
+        "ui": {
+            "slug": ""
+        },
+        "containers": {
+            "foldingathome-linuxserver": {
+                "image": "linuxserver/foldingathome",
+                "tag": "latest",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "-e",
+                        "NVIDIA_VISIBLE_DEVICES=all"
+                    ]
+                ],
+                "ports": {
+                    "7396": {
+                        "description": "Folding@Home WebUI port. Suggested default: 7396",
+                        "host_default": 7396,
+                        "label": "WebUI port",
+                        "ui": true
+                    },
+                    "36330": {
+                        "description": "Optional port for FAHControl app (no password). Suggested default: 36330",
+                        "host_default": 36330,
+                        "label": "FAHControl app port"
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a share for Folding@home to use. Eg: create a share called foldingathome for this purpose alone.",
+                        "label": "Config"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid system UserID for Folding@home. Must have full permissions on the previous Share.",
+                        "label": "PUID",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid system GroupID for Folding@home. This group or the above UserID must have full permissions on the previous Share.",
+                        "label": "PGID",
+                        "index": 2
+                    }
+                }
+            }
+        }
+    }
+}

--- a/root.json
+++ b/root.json
@@ -14,6 +14,7 @@
     "Duplicati - by Linuxserver.io": "duplicati-lsio.json",
     "ecoDMS 18.09": "ecodms18-09.json",
     "Emby server": "embyserver.json",
+    "Folding@home Linuxserver.io": "foldingathome-linuxserver.json",
     "FreshRSS": "FreshRSS.json",
     "Ghost": "ghost.json",
     "GitLab CE": "gitlab-rc.json",


### PR DESCRIPTION
Includes:
- root.json addition.
- Nvidia env hard wired for simplicity in anticipation of future GPU capabilities within the Rock-on system via a newer docker subsystem.

Fixes #219

@FroggyFlox Ready for review.
Note that I have slight concerns about the use of the '@' char in the root.json file. Easier for us to test post pull request submission however.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Folding@home
- website: https://foldingathome.org/
- description: "...distributed computing project for simulating protein dynamics, including the process of protein folding and the movements of proteins implicated in a variety of diseases." quoted from their about page. This project is of recognised scientific import and depends on community members volunteering part of their CPU / GPU hardware resources.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/foldingathome
- is an official docker image available for this project?: I couldn't find one, however linuxserver.io are a trusted supplier and often offer UID & GID capabilities over and above many official docker images and their offering for this project was updated 4 days ago.

### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website

### Testing:
- Stopping and Starting works as expected and successfully resumes an ongoing FAH ‘Work Unit’.
- Turning off, Un-installing, and then Re-installing with the same share also successfully resumes the FAH ‘Work Unit’.
- After a Rockstor system reboot the Rock-on also successfully resumed the current FAH ‘Work Unit’.
- N.B. the optional FAHControl app was note tested, and neither was wiping the entry of this optional port selection (i.e. establishing if it was actually optional within the Rock-on framework).
