### PR TITLE
add postgres-10.6.json to root.json & normalise with 9.5 variant. Fixes #221

### DIFF
--- a/postgres-10.6.json
+++ b/postgres-10.6.json
@@ -1,34 +1,40 @@
 {
-    "PostgreSQL 10.6":{
-        "containers":{
-            "postgresql":{
+    "PostgreSQL 10.6": {
+        "description": "PostgreSQL (10.6), open-source relational DBMS.<p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.</p><p><strong>Note: </strong>This rock-on requires Rockstor version 3.9.2-53 or later.</p>",
+        "version": "1.2",
+        "website": "https://www.postgresql.org",
+        "more_info": "<h4>Important locations inside docker image:</h4><p>Config. file:<code>/var/lib/pgsql/data/pg_hba.conf</code></p> <p>Databases: <code>/var/lib/pgsql/data</code></p> <p>Logs: <code>/var/log/postgresql</code></p>",
+        "volume_add_support": true,
+        "containers": {
+            "postgresql": {
                 "image": "postgres",
+                "launch_order": 1,
                 "tag": "10.6",
-                "launch_order":1,
-                "ports":{
-                    "5432":{
-                        "description":"PostgreSQL port. Suggested default: 5433",
-                        "host_default":5433,
-                        "label":"PostgreSQL port",
-                        "protocol":"tcp",
-                        "ui":false
+                "ports": {
+                    "5432": {
+                        "description": "PostgreSQL port. Suggested default: 5433 (Rockstor typically uses 5432 already)",
+                        "host_default": 5433,
+                        "label": "PostgreSQL port",
+                        "protocol": "tcp"
                     }
                 },
-                "volumes":{
-                    "/var/lib/postgresql/data":{
-                        "description":"Choose a share where the database should be stored. Eg: create a share called postgresql-share1 for this purpose alone. ",
-                        "label":"Data Storage"
+                "volumes": {
+                    "/var/lib/postgresql/data": {
+                        "description": "Choose a share where the database should be stored. E.g.: create a share called postgresql106-data for this purpose alone.",
+                        "label": "Data Storage"
+                    }
+                },
+                "environment": {
+                    "POSTGRES_USER": {
+                        "description": "Choose A Super User name for the PostgreSQL installation",
+                        "label": "SuperUser"
+                    },
+                    "POSTGRES_PASSWORD": {
+                        "description": "set a password for the Super User.",
+                        "label": "SuperUser password"
                     }
                 }
             }
-        },
-        "description": "PostgreSQL v10.6, open-source relational database management system. <p><strong>Note: </strong>This rock-on requires Rockstor version 3.9.2-51 or later.</p><p>Based on the official PostgreSQL docker image: <a href='https://hub.docker.com/_/postgres' target='_blank'>https://hub.docker.com/_/postgres</a>.",
-        "ui":{
-            "slug":""
-        },
-        "volume_add_support":true,
-        "more_info": "<h4>Important locations</h4><p>Configuration file:<code>/var/lib/pgsql/data/pg_hba.conf</code></p> <p>Databases: <code>/var/lib/pgsql/data</code></p> <p>Logs: <code>/var/log/postgresql</code></p>",
-        "website":"https://www.postgresql.org",
-        "version":"1.0"
+        }
     }
 }

--- a/postgres-10.6.json
+++ b/postgres-10.6.json
@@ -6,7 +6,7 @@
         "more_info": "<h4>Important locations inside docker image:</h4><p>Config. file:<code>/var/lib/pgsql/data/pg_hba.conf</code></p> <p>Databases: <code>/var/lib/pgsql/data</code></p> <p>Logs: <code>/var/log/postgresql</code></p>",
         "volume_add_support": true,
         "containers": {
-            "postgresql": {
+            "postgresql-10.6": {
                 "image": "postgres",
                 "launch_order": 1,
                 "tag": "10.6",

--- a/root.json
+++ b/root.json
@@ -52,6 +52,7 @@
     "Plexpy": "plexpy.json",
     "PocketMine": "pocketmine.json",
     "PostgreSQL 9.5": "postgres-9.5.json",
+    "PostgreSQL 10.6": "postgres-10.6.json",
     "Radarr": "radarr.json",
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",


### PR DESCRIPTION
See issue text for info/context.

Fixes #221

### General information on pr
This pull request simply harmonises our 2 postgresql Rock-ons with regard to their user facing text and options. Our 9.5 version was influenced by our 10.6 version, but the latter was merged later. Both were community contributions thus:

For 9.5 see:  pr #217 by @Hooverdan96 
For 10.6 see: pr #190 by @holmesb 

N.B. A key element of this harmonising was the adding of admin user and password elements taken from 10.6 (added by @Hooverdan96) and retrofitted to 9.5.

### Checklist (pertaining to v10.6)
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)

