### PR TITLE
add NodeRed rock-on

### DIFF
--- a/nodered.json
+++ b/nodered.json
@@ -1,0 +1,31 @@
+{
+    "Node-Red": {
+        "containers": {
+            "nodered": {
+                "image": "nodered/node-red",
+                "launch_order": 1,
+                "ports": {
+                    "1880": {
+                        "description": "Node-Red WebUI port. Suggested default: 1880",
+                        "host_default": 1880,
+                        "label": "WebUI port",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/shared": {
+                        "description": "Choose a Share for Node-Red. Eg: create a Share called nodered-data for this purpose alone.",
+                        "label": "Storage",
+                        "min_size": 1073741824
+                    }
+                }
+            }
+        },
+            "version": "latest",
+        "description": "Low-code programming for event-driven applications",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://nodered.org"
+    }
+}

--- a/nodered.json
+++ b/nodered.json
@@ -1,8 +1,9 @@
 {
-    "Node-Red": {
+    "Node_red - by nodered.org":{
         "containers": {
             "nodered": {
                 "image": "nodered/node-red",
+                "tag": "latest",
                 "launch_order": 1,
                 "ports": {
                     "1880": {
@@ -22,7 +23,7 @@
             }
         },
             "version": "latest",
-        "description": "Low-code programming for event-driven applications",
+        "description": "Low-code programming for event-driven applications. Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways.",
         "ui": {
             "slug": ""
         },

--- a/nodered.json
+++ b/nodered.json
@@ -1,5 +1,5 @@
 {
-    "Node_red - by nodered.org":{
+    "Node-Red - by nodered.org":{
         "containers": {
             "nodered": {
                 "image": "nodered/node-red",
@@ -23,7 +23,8 @@
             }
         },
             "version": "latest",
-        "description": "Low-code programming for event-driven applications. Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways.",
+        "description": "Low-code programming for event-driven applications. Node-Red is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways. <p>Based on Node-Red docker image: docker image: <a href='https://hub.docker.com/r/nodered/node-red' target='_blank'>https://hub.docker.com/r/nodered/node-red</a>.",
+        "more_info": "Browser-based flow editing that makes it easy to wire together flows using the wide range of nodes in the palette. Javascript functions can be created within the editor. A built-in editor allows you to save useful functions.",
         "ui": {
             "slug": ""
         },

--- a/nodered.json
+++ b/nodered.json
@@ -1,5 +1,5 @@
 {
-    "Node-Red - by nodered.org":{
+    "Node-RED by nodered.org":{
         "containers": {
             "nodered": {
                 "image": "nodered/node-red",
@@ -7,7 +7,7 @@
                 "launch_order": 1,
                 "ports": {
                     "1880": {
-                        "description": "Node-Red WebUI port. Suggested default: 1880",
+                        "description": "Node-RED WebUI port. Suggested default: 1880",
                         "host_default": 1880,
                         "label": "WebUI port",
                         "ui": true
@@ -15,7 +15,7 @@
                 },
                 "volumes": {
                     "/shared": {
-                        "description": "Choose a Share for Node-Red. Eg: create a Share called nodered-data for this purpose alone.",
+                        "description": "Choose a Share for Node-RED. Eg: create a Share called nodered-data for this purpose alone.",
                         "label": "Storage",
                         "min_size": 1073741824
                     }
@@ -23,7 +23,7 @@
             }
         },
             "version": "latest",
-        "description": "Low-code programming for event-driven applications. Node-Red is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways. <p>Based on Node-Red docker image: docker image: <a href='https://hub.docker.com/r/nodered/node-red' target='_blank'>https://hub.docker.com/r/nodered/node-red</a>.",
+        "description": "Low-code programming for event-driven applications. Node-RED is a programming tool for wiring together hardware devices, APIs and online services in new and interesting ways. <p>Based on the official Node-RED docker image: <a href='https://hub.docker.com/r/nodered/node-red' target='_blank'>https://hub.docker.com/r/nodered/node-red</a>.",
         "more_info": "Browser-based flow editing that makes it easy to wire together flows using the wide range of nodes in the palette. Javascript functions can be created within the editor. A built-in editor allows you to save useful functions.",
         "ui": {
             "slug": ""

--- a/root.json
+++ b/root.json
@@ -40,6 +40,7 @@
     "Nextcloud-Official": "nextcloud-official.json",
     "Nginx Proxy Manager": "NginxProxyManager.json",
     "Nginx": "nginx.json",
+    "Node-Red": "nodered.json",
     "NZBGet": "nzbget.json",
     "NZBHydra": "NZBHydra.json",
     "Ombi": "ombi.json",


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes # .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: NodeRed
- website: https://nodered.org
- description: Low-code programming for event-driven applications. This is programming tool for wiring together hardware devices, API's and online services. Alternatives are n8n.io, ioBroker, AWS  IoT & ThingsBoard.io to name a few.

### Information on docker image
- docker image: https://hub.docker.com/r/nodered/node-red
- is an official docker image available for this project?: No


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
