### PR TITLE
add minetest server

### DIFF
--- a/minetest.json
+++ b/minetest.json
@@ -34,11 +34,6 @@
                         "description": "Enter timezone e.g Europe/London these can be found ...",
                         "label": "Timezone to run minetest server in.",
                         "index": 3
-                    },
-                    "CLI_ARGS": {
-                        "description": "Optional args to pass.",
-                        "label": "CLI arguments to pass to minetest server",
-                        "index": 4
                     }
                 }
             }

--- a/minetest.json
+++ b/minetest.json
@@ -38,7 +38,7 @@
                 }
             }
         },
-        "description": "An open source voxel game engine clone of the popular Minecraft, see <em>more info</em> for details.</p><p>Based on the docker image by <a href='https://www.linuxserver.io/' target='_blank'>Linuxserver.io</a>: <a href='https://hub.docker.com/r/linuxserver/minetest' target='_blank'>https://hub.docker.com/r/linuxserver/minetest</a>, available for amd64, arm32v7 and arm64v8.</p>",
+        "description": "An open source voxel game engine clone of the popular Minecraft, see <em>more info</em> for details.</p><p>Based on the docker image by <a href='https://www.linuxserver.io/' target='_blank'>Linuxserver.io</a>: <a href='https://hub.docker.com/r/linuxserver/minetest' target='_blank'>https://hub.docker.com/r/linuxserver/minetest</a>, available for amd64 and arm64 architecture.</p>",
         "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Minetest-logo.svg/110px-Minetest-logo.svg.png",
         "more_info": "<p>Documentation on how to configure minetest server can be found here: <a href='https://wiki.minetest.net/Setting_up_a_server' target='_blank'>wiki.minetest.net/Setting_up_a_server</a>.</p>",
         "ui": {

--- a/minetest.json
+++ b/minetest.json
@@ -1,0 +1,56 @@
+{
+    "Minetest": {
+        "containers": {
+            "minetest": {
+                "image": "linuxserver/minetest",
+                "launch_order": 1,
+                "ports": {
+                    "30000": {
+                        "description": "Minetest port. Suggested default: 30000",
+                        "host_default": 30000,
+                        "label": "Minetest port",
+                        "protocol": "udp",
+                        "ui": false
+                    }
+                },
+                "volumes": {
+                    "/config/.minetest": {
+                        "description": "Choose a Share for minetest configuration. Eg: create a Share called minetest-config for this purpose alone.",
+                        "label": "Config Storage"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid UID to run minetest as. It must have full permissions to the Share mapped in the previous step.",
+                        "label": "UID to run minetest as.",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to the Share mapped in the previous step.",
+                        "label": "GID to run minetest as.",
+                        "index": 2
+                    },
+                    "TZ": {
+                        "description": "Enter timezone e.g Europe/London these can be found ...",
+                        "label": "Timezone to run minetest server in.",
+                        "index": 3
+                    },
+                    "CLI_ARGS": {
+                        "description": "Optional args to pass.",
+                        "label": "CLI arguments to pass to minetest server",
+                        "index": 4
+                    }
+                }
+            }
+        },
+        "description": "An open source voxel game engine clone of the popular Minecraft, see <em>more info</em> for details.</p><p>Based on the linuxserver/minetest docker image: <a href='https://hub.docker.com/r/linuxserver/minetest' target='_blank'>https://hub.docker.com/r/linuxserver/minetest</a>.</p>",
+        "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Minetest-logo.svg/110px-Minetest-logo.svg.png",
+        "more_info": "<p>Documentation on how to configure minetest server can be found here: <a href='https://wiki.minetest.net/Setting_up_a_server' target='_blank'>wiki.minetest.net/Setting_up_a_server</a>.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "website": "http://minetest.net/",
+        "version": "1.0"
+    }
+}

--- a/minetest.json
+++ b/minetest.json
@@ -38,7 +38,7 @@
                 }
             }
         },
-        "description": "An open source voxel game engine clone of the popular Minecraft, see <em>more info</em> for details.</p><p>Based on the linuxserver/minetest docker image: <a href='https://hub.docker.com/r/linuxserver/minetest' target='_blank'>https://hub.docker.com/r/linuxserver/minetest</a>.</p>",
+        "description": "An open source voxel game engine clone of the popular Minecraft, see <em>more info</em> for details.</p><p>Based on the docker image by <a href='https://www.linuxserver.io/' target='_blank'>Linuxserver.io</a>: <a href='https://hub.docker.com/r/linuxserver/minetest' target='_blank'>https://hub.docker.com/r/linuxserver/minetest</a>, available for amd64, arm32v7 and arm64v8.</p>",
         "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/73/Minetest-logo.svg/110px-Minetest-logo.svg.png",
         "more_info": "<p>Documentation on how to configure minetest server can be found here: <a href='https://wiki.minetest.net/Setting_up_a_server' target='_blank'>wiki.minetest.net/Setting_up_a_server</a>.</p>",
         "ui": {

--- a/minetest.json
+++ b/minetest.json
@@ -31,7 +31,7 @@
                         "index": 2
                     },
                     "TZ": {
-                        "description": "Enter timezone e.g Europe/London these can be found ...",
+                        "description": "Enter timezone e.g Europe/London (see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).",
                         "label": "Timezone to run minetest server in.",
                         "index": 3
                     }

--- a/root.json
+++ b/root.json
@@ -35,6 +35,7 @@
     "MariaDB": "mariadb.json",
     "Medusa": "medusa.json",
     "Minecraft": "minecraft.json",
+    "Minetest": "minetest.json",
     "MinIO": "minio.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes # .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Minetest
- website: minetest.net
- description: Rockon for minetest server

### Information on docker image
- docker image: r/linuxserver/minetest
- is an official docker image available for this project?: 
using the linuxserver.io image

### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
