### PR TITLE
Add MinIO Rock-on #231

### DIFF
--- a/minio.json
+++ b/minio.json
@@ -1,31 +1,31 @@
 {
-    "Minio": {
-        "description": "Minio is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.",
+    "MinIO": {
+        "description": "MinIO is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.",
         "version": "1.0",
         "website": "https://minio.io",
-        "more_info": "This Rock-on uses the official Minio Docker image to implement a single Minio instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",
+        "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",
         "ui": {
             "https": false,
             "slug": ""
         },
         "volume_add_support": false,
         "containers": {
-            "Minio": {
+            "MinIO": {
                 "image": "minio/minio",
                 "launch_order": 1,
                 "ports": {
                     "9000": {
                         "description": "API and Portal access, default 9000",
                         "host_default": 9000,
-                        "label": "Minio API and Portal",
+                        "label": "MinIO API and Portal",
                         "protocol": "tcp",
                         "ui": true
                     }
                 },
                 "volumes": {
                     "/data": {
-                        "description": "Choose a share for Minio object storage",
-                        "label": "Minio Object Storage"
+                        "description": "Choose a share for MinIO object storage",
+                        "label": "MinIO Object Storage"
                     }
                 },
                 "cmd_arguments": [
@@ -36,12 +36,12 @@
                 ],
                 "environment": {
                     "MINIO_ACCESS_KEY": {
-                        "description": "Minio Access Key (admin username), 1 to 128 alphanumeric characters",
-                        "label": "Minio Access Key"
+                        "description": "MinIO Access Key (admin username), 1 to 128 alphanumeric characters",
+                        "label": "MinIO Access Key"
                     },
                     "MINIO_SECRET_KEY": {
-                        "description": "Minio Secret Key (admin password), 1 to 128 alphanumeric characters",
-                        "label": "Minio Secret Key"
+                        "description": "MinIO Secret Key (admin password), 1 to 128 alphanumeric characters",
+                        "label": "MinIO Secret Key"
                     },
                     "MINIO_BROWSER": {
                         "description": "Web Portal admin access, on to enable, off to disable",

--- a/minio.json
+++ b/minio.json
@@ -1,6 +1,6 @@
 {
     "Minio": {
-        "description": "Minio is an S3-compatible object storage server",
+        "description": "Minio is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.",
         "version": "1.0",
         "website": "https://minio.io",
         "more_info": "This Rock-on uses the official Minio Docker image to implement a single Minio instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",

--- a/minio.json
+++ b/minio.json
@@ -1,6 +1,6 @@
 {
     "MinIO": {
-        "description": "MinIO is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.<p>Based on the official MinIO docker image: <a href='https://hub.docker.com/r/minio/minio' target='_blank'>https://hub.docker.com/r/minio/minio</a>.",
+        "description": "MinIO is an S3-compatible object storage server. This rock-on requires Rockstor 3.9.2-39 or later and is compatible with x86_64/amd64 machines only.<p>Based on the official MinIO docker image: <a href='https://hub.docker.com/r/minio/minio' target='_blank'>https://hub.docker.com/r/minio/minio</a>.",
         "version": "1.0",
         "website": "https://minio.io",
         "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",

--- a/minio.json
+++ b/minio.json
@@ -1,0 +1,54 @@
+{
+    "Minio": {
+        "description": "Minio is an S3-compatible object storage server",
+        "version": "1.0",
+        "website": "https://minio.io",
+        "more_info": "This Rock-on uses the official Minio Docker image to implement a single Minio instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",
+        "ui": {
+            "https": false,
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "containers": {
+            "Minio": {
+                "image": "minio/minio",
+                "launch_order": 1,
+                "ports": {
+                    "9000": {
+                        "description": "API and Portal access, default 9000",
+                        "host_default": 9000,
+                        "label": "Minio API and Portal",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/data": {
+                        "description": "Choose a share for Minio object storage",
+                        "label": "Minio Object Storage"
+                    }
+                },
+                "cmd_arguments": [
+                    [
+                        "server",
+                        "/data"
+                    ]
+                ],
+                "environment": {
+                    "MINIO_ACCESS_KEY": {
+                        "description": "Minio Access Key (admin username), 1 to 128 alphanumeric characters",
+                        "label": "Minio Access Key"
+                    },
+                    "MINIO_SECRET_KEY": {
+                        "description": "Minio Secret Key (admin password), 1 to 128 alphanumeric characters",
+                        "label": "Minio Secret Key"
+                    },
+                    "MINIO_BROWSER": {
+                        "description": "Web Portal admin access, on to enable, off to disable",
+                        "label": "Web Portal Access"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/minio.json
+++ b/minio.json
@@ -1,6 +1,6 @@
 {
     "MinIO": {
-        "description": "MinIO is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.",
+        "description": "MinIO is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.<p>Based on the official MinIO docker image: <a href='https://hub.docker.com/r/minio/minio' target='_blank'>https://hub.docker.com/r/minio/minio</a>.",
         "version": "1.0",
         "website": "https://minio.io",
         "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",

--- a/root.json
+++ b/root.json
@@ -34,7 +34,7 @@
     "MariaDB": "mariadb.json",
     "Medusa": "medusa.json",
     "Minecraft": "minecraft.json",
-    "Minio": "minio.json",
+    "MinIO": "minio.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",
     "Netdata": "netdata.json",

--- a/root.json
+++ b/root.json
@@ -34,6 +34,7 @@
     "MariaDB": "mariadb.json",
     "Medusa": "medusa.json",
     "Minecraft": "minecraft.json",
+    "Minio": "minio.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",
     "Netdata": "netdata.json",


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes # 231.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: MinIO
- website: https://min.io/
- description: MinIO is an S3-compatible object storage server.  Requires Rockstor 3.9.2-39 or later.

### Information on docker image
- docker image: https://hub.docker.com/r/minio/minio
- is an official docker image available for this project?: yes


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
