### PR TITLE
Add wallabag

### DIFF
--- a/root.json
+++ b/root.json
@@ -67,6 +67,7 @@
     "Ubiquiti Unifi linuxserver.io": "unifi-linuxserver.json",
     "Unifi Controller": "unifi.json",
     "Vaultwarden": "vaultwarden.json",
+    "wallabag": "wallabag.json",
     "Watchtower official": "watchtower_official.json",
     "Web Service Discovery For Windows Networks": "wsdd.json",
     "YouTrack official": "youtrack-official.json",

--- a/wallabag.json
+++ b/wallabag.json
@@ -1,6 +1,6 @@
 {
     "wallabag": {
-        "description": "<p>wallabag is a self hostable application for saving web pages.</p><p>Based on the official wallabag docker image: <a href='https://hub.docker.com/r/wallabag/wallabag/' target='_blank'>https://hub.docker.com/r/wallabag/wallabag/</a>.</p>",
+        "description": "<p>wallabag is a self hostable application for saving web pages.</p><p>This rock-on relies on having a dedicated domain name for proper operation.</p><p>Based on the official wallabag docker image: <a href='https://hub.docker.com/r/wallabag/wallabag/' target='_blank'>https://hub.docker.com/r/wallabag/wallabag/</a>.</p>",
         "ui": {
             "slug": ""
         },

--- a/wallabag.json
+++ b/wallabag.json
@@ -1,0 +1,69 @@
+{
+    "wallabag": {
+        "description": "wallabag is a self hostable application for saving web pages.",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://wallabag.org/",
+        "version": "2.0",
+        "containers": {
+            "wallabag": {
+                "image": "wallabag/wallabag",
+                "launch_order": 1,
+                "volumes": {
+                    "/var/www/wallabag/data": {
+                        "description": "Choose a Share for the database. Eg: create a Share called wallabag-db for this purpose.",
+                        "label": "Database"
+                    },
+                    "/var/www/wallabag/web/assets/images": {
+                        "description": "Choose a Share for images and such. Eg: create a Share called wallabag-assets for this purpose.",
+                        "label": "Assets"
+                    }
+                },
+                "ports": {
+                    "80": {
+                        "description": "Wallabag webserver port. Defaults to 80",
+                        "label": "Web server",
+                        "host_default": 80,
+                        "ui": true
+                    }
+                },
+                "environment": {
+                    "SYMFONY__ENV__SECRET": {
+                        "label": "secret",
+                        "description": "Set a secret"
+                    },
+                    "SYMFONY__ENV__MAILER_HOST": {
+                        "label": "Mail host",
+                        "description": "defaults to 127.0.0.1, the SMTP host"
+                    },
+                    "SYMFONY__ENV__MAILER_USER": {
+                        "label": "Mail user",
+                        "description": "defaults to ~, the SMTP user"
+                    },
+                    "SYMFONY__ENV__MAILER_PASSWORD": {
+                        "label": "Mail password",
+                        "description": "defaults to ~, the SMTP password"
+                    },
+                    "SYMFONY__ENV__FROM_EMAIL": {
+                        "label": "Mail sender",
+                        "description": "defaults to wallabag@example.com, the address wallabag uses for outgoing emails"
+                    },
+                    "SYMFONY__ENV__TWOFACTOR_SENDER": {
+                        "label": "Twofactor email sender",
+                        "description": "defaults to no-reply@wallabag.org, the address wallabag uses for two-factor emails"
+                    },
+                    "SYMFONY__ENV__FOSUSER_REGISTRATION": {
+                        "label": "Allow user registration",
+                        "description": "Defaults to true. Set to false to disable public user registration"
+                    },
+                    "SYMFONY__ENV__DOMAIN_NAME": {
+                        "label": "Domain name",
+                        "description": "Public domain name wallabag should assume (including protocol)"
+                    }
+                }
+            }
+        },
+        "more_info": "<p>Default login is wallabag:wallabag.</p>"
+    }
+}

--- a/wallabag.json
+++ b/wallabag.json
@@ -1,6 +1,6 @@
 {
     "wallabag": {
-        "description": "wallabag is a self hostable application for saving web pages.",
+        "description": "<p>wallabag is a self hostable application for saving web pages.</p><p>Based on the official wallabag docker image: <a href='https://hub.docker.com/r/wallabag/wallabag/' target='_blank'>https://hub.docker.com/r/wallabag/wallabag/</a>.</p>",
         "ui": {
             "slug": ""
         },


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: wallabag
- website: https://wallabag.org
- description: Bookmarking/read it later service.

### Information on docker image
- docker image: https://hub.docker.com/r/wallabag/wallabag/
- is an official docker image available for this project?:  Yes. That's the one, see also https://doc.wallabag.org/en/admin/installation/installation.html#installation-with-docker


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
