### PR TITLE
Update netdata rock-on. Fixes #236

### DIFF
--- a/netdata-official.json
+++ b/netdata-official.json
@@ -1,5 +1,5 @@
 {
-    "Netdata": {
+    "Netdata (official)": {
         "containers": {
             "netdata": {
                 "image": "netdata/netdata",
@@ -36,7 +36,7 @@
                 ],
                 "ports": {
                     "19999": {
-                        "description": "port used to access the webUI port",
+                        "description": "Port used to access the webUI port. MUST be 19999.",
                         "host_default": 19999,
                         "label": "webUI port",
                         "ui": true
@@ -44,12 +44,12 @@
                 },
                 "environment": {
                     "PGID": {
-                        "description": "GID of the docker group. Run `grep docker /etc/group | cut -d ':' -f 3` to find it.",
+                        "description": "GID of the 'docker' group. See System - Identity - Groups in Rockstor's UI to find it.",
                         "label": "PGID",
                         "index": 1,
-                        "default":472
+                        "default": 472
                     }
-				}
+                }
             }
         },
         "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/netdata/netdata' target='_blank'>https://hub.docker.com/r/netdata/netdata</a>, available on x86_64/amd64, and aarch64/arm64.</p>",
@@ -59,6 +59,6 @@
         "ui": {
             "slug": ""
         },
-	    "version": "1.0"
+        "version": "1.0"
     }
 }

--- a/netdata.json
+++ b/netdata.json
@@ -2,12 +2,16 @@
     "Netdata": {
         "containers": {
             "netdata": {
-                "image": "titpetric/netdata",
+                "image": "netdata/netdata",
                 "launch_order": 1,
                 "opts": [
                     [
                         "--cap-add=SYS_PTRACE",
                         ""
+                    ],
+                    [
+                        "--security-opt",
+                        "apparmor=unconfined"
                     ],
                     [
                         "--net=host",
@@ -24,6 +28,10 @@
                     [
                         "-v",
                         "/sys:/host/sys:ro"
+                    ],
+                    [
+                        "-v",
+                        "/etc/os-release:/etc/os-release:ro"
                     ]
                 ],
                 "ports": {
@@ -34,18 +42,20 @@
                         "ui": true
                     }
                 },
-                "volumes": {
-                    "/etc/netdata/override": {
-                        "description": "Choose a Share for Netdata configuration files. All configuration files for custom plugins and alerts placed here will override defaults.",
-                        "label": "Config Storage"
+                "environment": {
+                    "PGID": {
+                        "description": "GID of the docker group. Run `grep docker /etc/group | cut -d ':' -f 3` to find it.",
+                        "label": "PGID",
+                        "index": 1,
+                        "default":472
                     }
-                }
+				}
             }
         },
-        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p>",
+        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/netdata/netdata' target='_blank'>https://hub.docker.com/r/netdata/netdata</a>.</p>",
         "icon": "https://github.com/firehol/netdata/blob/master/web/images/seo-performance-64.png",
-        "more_info": "See https://github.com/firehol/netdata/wiki for more info.",
-        "website": "https://my-netdata.io/",
+        "more_info": "See https://learn.netdata.cloud/ for more info.",
+        "website": "https://www.netdata.cloud/",
         "ui": {
             "slug": ""
         },

--- a/netdata.json
+++ b/netdata.json
@@ -52,9 +52,9 @@
 				}
             }
         },
-        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/netdata/netdata' target='_blank'>https://hub.docker.com/r/netdata/netdata</a>.</p>",
+        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/netdata/netdata' target='_blank'>https://hub.docker.com/r/netdata/netdata</a>, available on x86_64/amd64, and aarch64/arm64.</p>",
         "icon": "https://github.com/firehol/netdata/blob/master/web/images/seo-performance-64.png",
-        "more_info": "See https://learn.netdata.cloud/ for more info.",
+        "more_info": "See <a href='https://learn.netdata.cloud/' target='_blank'>https://learn.netdata.cloud/</a> for more info.",
         "website": "https://www.netdata.cloud/",
         "ui": {
             "slug": ""

--- a/root.json
+++ b/root.json
@@ -36,7 +36,7 @@
     "Minecraft": "minecraft.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",
-    "Netdata": "netdata.json",
+    "Netdata (official)": "netdata-official.json",
     "Nextcloud-Official": "nextcloud-official.json",
     "Nginx Proxy Manager": "NginxProxyManager.json",
     "Nginx": "nginx.json",


### PR DESCRIPTION
Fixes #236.
@phillxnet , ready for review.

As detailed in issue #236, we need to update our current Netdata rock-on to fix a few problems:
- log spam by auditd due to misconfiguration of the container with regards to Apparmor
- out-of-date version of Netdata due to not using the official image

This PR thus proposes to:
- correctly use the correct apparmor profile (unconfined)
- switch to the official netdata/netdata image as it is kept up-to-date, is multi-arch, and allows for better customizations. The only drawback is the loss of the configuration override volume that was bound in our current rock-on, but I believe it isn't a big problem anyway.
- update links to website (general project and documentation)


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
