### PR TITLE
Addresses #233 Watchtower Rock-on Issue (Part 1) - new official Watchtower container

### DIFF
--- a/root.json
+++ b/root.json
@@ -74,6 +74,7 @@
     "Unifi Controller": "unifi.json",
     "uTorrent": "uTorrent.json",
     "Watchtower": "watchtower.json",
+    "Watchtower offical": "watchtower_official.json",
     "Xeoma Video Surveillance": "xeoma.json",
     "YouTrack official": "youtrack-official.json",
     "Zabbix-XXL": "zabbix-xxl.json",

--- a/watchtower_official.json
+++ b/watchtower_official.json
@@ -1,0 +1,42 @@
+{
+	"Watchtower Official": {
+		"website": "https://containrrr.github.io/watchtower",
+		"version": "1.1",
+		"description": "A process for automating Docker container base image updates.<p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>CRON Generator</a></p><p>Based on official docker image: <a href='https://hub.docker.com/r/containrrr/watchtower' target=_blank'> https://hub.docker.com/r/containrrr/watchtower</a>, available for amd64, arm32v7, and arm64v8. </p>",
+		"more_info": "<h4>Tips for CRON expressions</h4><p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>Freeformatter.com: CRON Generator</a></p> <h4>Watchtower Container Labels</h4><p>In order to add labels to the containers to be watched by the Watchtower application (including Watchtower itself, if so desired), stop the corresponding container, and select the 'Add Label' under settings. The new label name must contain the entire flag setting, and should be entered like this:</p><p><code>com.centurylinklabs.watchtower.enable=true</code> if the value for <code>WATCHTOWER_LABEL_ENABLE</code> is set to true or</p><p><code>com.centurylinklabs.watchtower.enable=false</code> if the value is set to false.</p><p>More information can be found here: <a href='https://containrrr.dev/watchtower/container-selection/' target=_blank>Watchtower Container Selection</a></p>",
+		"containers": {
+			"watchtower_official": {
+				"image": "containrrr/watchtower",
+				"tag": "latest",
+				"launch_order": 1,
+				"opts": [
+					[
+						"-v",
+						"/var/run/docker.sock:/var/run/docker.sock"
+					],
+					[
+						"--privileged",
+						""
+                    ]
+				],
+				"environment": {
+					"WATCHTOWER_LABEL_ENABLE": {
+						"description": "If this flag is set to 'true', containers with a specific label string (see the 'More info' icon) will be updated (you can use the 'Add label' functionality to add labels after installing Rockons). If the flag is set to 'false', containers with the label will be excluded. It is recommended to set it to true during installation. Note: Only running containers will be considered.",
+						"label": "Filter by label enable",
+						"index": 1
+					},
+					"WATCHTOWER_SCHEDULE": {
+						"description": "CRON expression (6 fields) defining when and how often to check for new images. E.g.: to have Watchtower check every month on the 1st, at noon (include spaces in between values): 0 0 12 1 * ?",
+						"label": "Scheduling (CRON format)",
+						"index": 2
+                    },
+                    "WATCHTOWER_CLEANUP": {
+						"description": "Removes old Images after updating. Setting the parameter to 'true' will remove old images, setting it to 'false' will keep old images untouched after the update. Recommended value is 'true' to avoid accumulation of old images, especially on regularly updated containers.",
+						"label": "Remove old images after update",
+						"index": 3
+                    }
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #233  .

### General information on project
This Pull Request will introduce the official docker container as a new Rock-on
modifier: root.json - added new Rock-On
new: watchtower_official.json - official docker container
This pull request proposes to add a new rock-on for the following project:
- name: Watchtower Official
- website: https://containrrr.github.io/watchtower
- description: Official container of Watchtower project to monitor and update existing Rock-ons periodically.

### Information on docker image
- docker image: https://hub.docker.com/r/containrrr/watchtower
- is an official docker image available for this project?: yes, this is it.


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
