### PR TITLE
New Rock-on: Scrutiny

### DIFF
--- a/root.json
+++ b/root.json
@@ -60,6 +60,7 @@
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",
     "sabnzb": "sabnzb.json",
+    "Scrutiny": "scrutiny.json",
     "Seafile": "Seafile.json",
     "SickChill": "sickchill.json",
     "SmokePing": "smokeping.json",

--- a/scrutiny.json
+++ b/scrutiny.json
@@ -69,7 +69,7 @@
                 }
             }
         },
-        "description": "<p><a href='https://github.com/AnalogJ/scrutiny'>Scrutiny</a> WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p>Based on custom docker image: <a href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
+        "description": "<p>WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p>Based on custom docker image: <a target='_blank' href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
 		"more_info": "<p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
 		"ui": {
 			"https": false,

--- a/scrutiny.json
+++ b/scrutiny.json
@@ -1,0 +1,82 @@
+{
+    "Scrutiny": {
+        "containers": {
+            "scrutiny": {
+                "image": "ghcr.io/linuxserver/scrutiny",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "--cap-add",
+                        "SYS_RAWIO"
+                    ],
+                    [
+                        "--cap-add",
+                        "SYS_RAWIO"
+                    ],
+                    [
+                        "--device",
+                        "/dev:/dev"
+                    ],
+                    [
+                        "-v",
+                        "/run/udev:/run/udev:ro"
+                    ],
+                    [
+                        "--privileged",
+                        ""
+                    ]
+                ],
+                "ports" : {
+                    "8080": {
+                        "description": "Port for scrutiny's web interface and API.",
+                        "host_default": 8080,
+                        "label": "WebUI HTTP port",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for Scrutiny config files. Eg: create a Share called Scrutiny-Share-Config for this purpose alone.",
+                        "label": "Config share"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid system UserID for Scrutiny. Must have full permissions on the previous Share.",
+                        "label": "UID",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid system GroupID for Scrutiny. This group or the above UserID must have full permissions on the previous Share.",
+                        "label": "GID",
+                        "index": 2
+                    },
+                    "SCRUTINY_API_ENDPOINT": {
+                        "description": "API endpoint of the scrutiny UI. Do not change unless using as a remote collector. Default: 'http://localhost:8080'",
+                        "label": "SCRUTINY_API_ENDPOINT",
+                        "index": 3
+                    },
+                    "SCRUTINY_WEB": {
+                        "description": "Run the web service. Default: 'true'",
+                        "label": "SCRUTINY_WEB",
+                        "index": 4
+                    },
+                    "SCRUTINY_COLLECTOR": {
+                        "description": "Run the metrics collector. Default: 'true'",
+                        "label": "SCRUTINY_COLLECTOR",
+                        "index": 5
+                    }
+                }
+            }
+        },
+        "description": "<p><p><a href='https://github.com/AnalogJ/scrutiny'>Scrutiny</a> WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p></p><p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
+		"more_info": "<p>Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p>",
+		"ui": {
+			"https": false,
+			"slug": ""
+		},
+		"volume_add_support": false,
+		"website": "https://github.com/AnalogJ/scrutiny",
+		"version": "1.0"
+    }
+}

--- a/scrutiny.json
+++ b/scrutiny.json
@@ -70,7 +70,7 @@
             }
         },
         "description": "<p>WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p><strong>Note: </strong>In order to access the devices, this container will run with privileged capabilities. More info can be found <a href='https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities' target='_blank'>here</a>.</p><p>Based on custom docker image: <a target='_blank' href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
-		"more_info": "<p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
+		"more_info": "<p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage' target='_blank'>Scrutiny GitHub</a></p>",
 		"ui": {
 			"https": false,
 			"slug": ""

--- a/scrutiny.json
+++ b/scrutiny.json
@@ -7,7 +7,7 @@
                 "opts": [
                     [
                         "--cap-add",
-                        "SYS_RAWIO"
+                        "SYS_ADMIN"
                     ],
                     [
                         "--cap-add",
@@ -69,8 +69,8 @@
                 }
             }
         },
-        "description": "<p><p><a href='https://github.com/AnalogJ/scrutiny'>Scrutiny</a> WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p></p><p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
-		"more_info": "<p>Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p>",
+        "description": "<p><a href='https://github.com/AnalogJ/scrutiny'>Scrutiny</a> WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p>Based on custom docker image: <a href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
+		"more_info": "<p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
 		"ui": {
 			"https": false,
 			"slug": ""

--- a/scrutiny.json
+++ b/scrutiny.json
@@ -69,7 +69,7 @@
                 }
             }
         },
-        "description": "<p>WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p>Based on custom docker image: <a target='_blank' href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
+        "description": "<p>WebUI for smartd S.M.A.R.T monitoring. Scrutiny is a Hard Drive Health Dashboard &amp; Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates from Backblaze.</p><p><strong>Note: </strong>In order to access the devices, this container will run with privileged capabilities. More info can be found <a href='https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities' target='_blank'>here</a>.</p><p>Based on custom docker image: <a target='_blank' href='https://hub.docker.com/r/linuxserver/scrutiny'>https://hub.docker.com/r/linuxserver/scrutiny</a>, available for x86-64, arm64, and armhf</p>",
 		"more_info": "<p><strong>Note:</strong>This image is updating the stats only once a day, if you see: '<i>No Devices Detected!</i>' after the installation, just wait 24 hours. <br>This process can also be triggered manually from the shell by executing the following command: <code>docker exec scrutiny scrutiny-collector-metrics run</code><br>More documentation on this can be found here: <a href='https://github.com/AnalogJ/scrutiny#usage'>Scrutiny GitHub</a></p>",
 		"ui": {
 			"https": false,


### PR DESCRIPTION
### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Scrutiny
- website: [https://github.com/AnalogJ/scrutiny](https://github.com/AnalogJ/scrutiny)
- description: Scrutiny is a Hard Drive Health Dashboard & Monitoring solution, merging manufacturer provided S.M.A.R.T metrics with real-world failure rates.

### Information on docker image
- docker image: [https://hub.docker.com/r/linuxserver/scrutiny](https://hub.docker.com/r/linuxserver/scrutiny)
- is an official docker image available for this project?: Yes


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
