### PR TITLE
Add new Netdata (official) rock-on

### DIFF
--- a/netdata-official.json
+++ b/netdata-official.json
@@ -1,0 +1,64 @@
+{
+    "Netdata (official)": {
+        "containers": {
+            "netdata_official": {
+                "image": "netdata/netdata",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "--cap-add=SYS_PTRACE",
+                        ""
+                    ],
+                    [
+                        "--security-opt",
+                        "apparmor=unconfined"
+                    ],
+                    [
+                        "--net=host",
+                        ""
+                    ],
+                    [
+                        "-v",
+                        "/var/run/docker.sock:/var/run/docker.sock"
+                    ],
+                    [
+                        "-v",
+                        "/proc:/host/proc:ro"
+                    ],
+                    [
+                        "-v",
+                        "/sys:/host/sys:ro"
+                    ],
+                    [
+                        "-v",
+                        "/etc/os-release:/etc/os-release:ro"
+                    ]
+                ],
+                "ports": {
+                    "19999": {
+                        "description": "Port used to access the webUI port. MUST be 19999.",
+                        "host_default": 19999,
+                        "label": "webUI port",
+                        "ui": true
+                    }
+                },
+                "environment": {
+                    "PGID": {
+                        "description": "GID of the 'docker' group. See System - Identity - Groups in Rockstor's UI to find it.",
+                        "label": "PGID",
+                        "index": 1,
+                        "default": 472
+                    }
+                }
+            }
+        },
+        "description": "Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS.<p>Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/netdata/netdata' target='_blank'>https://hub.docker.com/r/netdata/netdata</a>, available on x86_64/amd64, and aarch64/arm64.</p>",
+        "icon": "https://github.com/firehol/netdata/blob/master/web/images/seo-performance-64.png",
+        "more_info": "See <a href='https://learn.netdata.cloud/' target='_blank'>https://learn.netdata.cloud/</a> for more info.",
+        "website": "https://www.netdata.cloud/",
+        "ui": {
+            "slug": ""
+        },
+        "version": "1.0"
+    }
+}

--- a/root.json
+++ b/root.json
@@ -38,6 +38,7 @@
     "MinIO": "minio.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar.json",
+    "Netdata (official)": "netdata-official.json",
     "Nextcloud-Official": "nextcloud-official.json",
     "Nginx Proxy Manager": "NginxProxyManager.json",
     "Nginx": "nginx.json",


### PR DESCRIPTION
Fixes #236.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Netdata
- website: https://www.netdata.cloud/
- description: Netdata is a scalable, distributed, real-time, performance and health monitoring solution for Linux, FreeBSD and MacOS. Out of the box, it collects 1k to 5k metrics per server per second. It is the corresponding of running top, vmstat, iostat, iotop, sar, systemd-cgtop and a dozen more console tools in parallel. Netdata is very efficient in this: the daemon needs just 1% to 3% cpu of a single core.

### Information on docker image
- docker image: https://hub.docker.com/r/netdata/netdata
- is an official docker image available for this project?: Yes, this PR uses it.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
