### PR TITLE
Add qbittorrent + openvpn rock-on

### DIFF
--- a/qbittorrent-openvpn.json
+++ b/qbittorrent-openvpn.json
@@ -1,0 +1,67 @@
+{
+        "qBittorrent - OpenVPN": {
+                "website": "http://www.qbittorrent.org/",
+                "version": "1.0",
+                "description": "Docker container running the qBittorrent client with a WebUI while connected to OpenVPN. Advantage over the transmission bittorrent client is that qBittorrent also supports sequential downloading. Uses https://hub.docker.com/repository/docker/marenz/qbittorrent-openvpn as image.",
+                "more_info": "<p>Add your openvpn configuration file with the name \"openvpn.conf\" in the config share for this rock-on BEFORE you finish this guide. Otherwise you have to restart it after adding it.</p>",
+                "containers": {
+                        "qbittorrent-openvpn": {
+                                "image": "marenz/qbittorrent-openvpn",
+                                "launch_order": 1,
+                                "opts": [
+                                        [
+                                                "-v",
+                                                "/etc/localtime:/etc/localtime:ro"
+                                        ],
+                                        [
+                                                "--cap-add",
+                                                "NET_ADMIN"
+                                        ],
+                                        [
+                                                "--device",
+                                                "/dev/net/tun"
+                                        ]
+                                ],
+                                "volumes": {
+                                        "/config": {
+                                                "description": "Configuration for qbittorrent as well as the openvpn.conf file. It is best if you put a working openvpn.conf file in this share BEFORE you finish this guide, otherwise you have to restart the rock-on once you added it.",
+                                                "label": "Configuration for qbittorrent and openvpn"
+                                        },
+                                        "/downloads": {
+                                                "description": "Primary share used for downloads. You can add more after this guide",
+                                                "label": "Data storage"
+                                        }
+                                },
+                                "ports": {
+                                        "8080": {
+                                                "description": "qBittorrent web ui port",
+                                                "host_default": 8080,
+                                                "label": "WebUI port",
+                                                "protocol": "tcp",
+                                                "ui": true
+                                        }
+                                },
+                                "environment": {
+                                        "PUID": {
+                                                "description": "Enter a valid UID of an existing user with permission to media shares to run qBittorrent as.",
+                                                "label": "UID",
+                                                "index": 1,
+                                                "default":1000
+                                        },
+                                        "PGID": {
+                                                "description": "Enter a valid GID of an existing user with permission to media shares to run qBittorrent as.",
+                                                "label": "GID",
+                                                "index": 2,
+                                                "default":1000
+                                        },
+                                        "NET_LOCAL": {
+                                                "description": "Optional. The netmask of your local network if you want it to be reachable. Usually \"192.168.0.0/16\".",
+                                                "label": "local netmask",
+                                                "index": 3,
+                                                "default": "192.168.0.0/16"
+                                        }
+                                }
+                        }
+                }
+        }
+}

--- a/root.json
+++ b/root.json
@@ -57,6 +57,7 @@
     "PocketMine": "pocketmine.json",
     "PostgreSQL 9.5": "postgres-9.5.json",
     "PostgreSQL 10.6": "postgres-10.6.json",
+    "qBittorrent with OpenVPN": "qbittorrent-openvpn",
     "Radarr": "radarr.json",
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",


### PR DESCRIPTION
The existing torrent client transmission + openvpn unfortunately misses
a feature I very much like: sequential downloading.

Thus I added qbittorrent + openvpn.

This rock-on can also be used without openvpn if you simply select eth0
as the interface in the qbittorrent webui and don't provide a
configuration (not tested that scenario though).

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: qbittorrent + openvpn
- website: www.qbittorrent.org/
- description: A bittorrent client with the feature of sequential downloading.

### Information on docker image
- docker image: https://hub.docker.com/repository/docker/marenz/qbittorrent-openvpn based on https://hub.docker.com/r/linuxserver/qbittorrent
- is an official docker image available for this project?: No


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
