### PR TITLE
Rockon for the updated V4/Dev branch of Ombi.

### DIFF
--- a/Ombi-V4.json
+++ b/Ombi-V4.json
@@ -1,0 +1,46 @@
+{
+  "Ombi-V4/Dev": {
+    "containers": {
+      "ombi-v4/dev": {
+        "image": "linuxserver/ombi",
+        "tag": "development",
+        "launch_order": 1,
+        "ports": {
+          "3579": {
+            "description": "Ombi WebUI port. Suggested default: 3579",
+            "host_default": 3579,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/config": {
+            "description": "Choose a Share for Ombi configuration. Eg: create a Share called Ombi-config for this purpose alone.",
+            "label": "Config Storage"
+
+          }
+        },
+        "environment": {
+          "PUID": {
+            "description": "Enter a valid UID to run Ombi as. It must have full permissions to all Shares mapped in the previous step.",
+            "label": "UID to run Ombi as.",
+            "index": 1
+          },
+          "PGID": {
+            "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+            "label": "GID to run Ombi as.",
+            "index": 2
+          }
+        }
+      }
+    },
+    "description": "Ombi allows you to host your own Plex Request and user management system.  This Rockon loads the newer V4 branch of Ombi which is still in development.",
+    "ui": {
+      "slug": ""
+    },
+    "volume_add_support": true,
+    "website": "https://hub.docker.com/r/linuxserver/ombi/",
+    "version": "1.0"
+  }
+}

--- a/root.json
+++ b/root.json
@@ -47,6 +47,7 @@
     "NZBGet": "nzbget.json",
     "NZBHydra": "NZBHydra.json",
     "Ombi": "ombi.json",
+    "Ombi-V4/Dev": "Ombi-V4.json",
     "OpenVPN": "openvpn.json",
     "OwnCloud": "owncloud.json",
     "OwnCloud-Official": "owncloud-official.json",


### PR DESCRIPTION
Fixes # NA.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Ombi V4/Dev branch
- website: https://ombi.io/
- description: The only change from the current Ombi Rockon is the Docker tag and the description.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/ombi/
- is an official docker image available for this project?: Yes.


### Checklist
- [ * ] Passes [JSONlint](https://jsonlint.com) validation
- [ * ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [  ] `"description"` object lists and links to the docker image used
- [ * ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [ * ] `"website"` object links to project's main website
