### PR TITLE
Fix nginx-proxy-manager for rockstor 4

### DIFF
--- a/NginxProxyManager.json
+++ b/NginxProxyManager.json
@@ -4,6 +4,12 @@
 			"nginx-proxy": {
 				"image": "jlesage/nginx-proxy-manager",
 				"launch_order": 1,
+				"opts": [
+					[
+						"-e",
+						"DISABLE_IPV6=true"
+					]
+				],
 				"ports": {
 					"8181": {
 						"description": "Admin WebUI port",


### PR DESCRIPTION
As IPv6 is currently disabled, we also have to disable it for this rock-on via environment variables otherwise nginx will not start:

```
2021/02/11 20:35:31 [emerg] 14860#14860: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:32 [emerg] 14869#14869: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:33 [emerg] 14878#14878: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:34 [emerg] 14887#14887: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:35 [emerg] 14896#14896: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:36 [emerg] 14905#14905: socket() [::]:8080 failed (97: Address family not supported by protocol)
2021/02/11 20:35:37 [emerg] 14914#14914: socket() [::]:8080 failed (97: Address family not supported by protocol)
```
fyi @DarkYamik 

