### PR TITLE
Added NZBHydra2, as linuxserver.io have deprecated older hydra image

### DIFF
--- a/NZBHydra.json
+++ b/NZBHydra.json
@@ -37,7 +37,7 @@
                 }
             }
         },
-        "description": "NZBHydra is a meta search for NZB indexers. <p><strong>Important</strong>The docker image used by this rock-on has been deprecated by its authors and will thus be removed from Rockstor in the near future. We recommend you to use the NZBHydra2 rock-on instead.</p>",
+        "description": "NZBHydra is a meta search for NZB indexers. <p><strong>Important</strong> The docker image used by this rock-on has been deprecated by its authors and will thus be removed from Rockstor in the near future. We recommend you to use the NZBHydra2 rock-on instead.</p>",
         "ui": {
             "slug": ""
         },

--- a/NZBHydra.json
+++ b/NZBHydra.json
@@ -17,18 +17,18 @@
                     "/config": {
                         "description": "Choose a Share for nzbhydra configuration. Eg: create a Share called nzbhydra-config for this purpose alone.",
                         "label": "Config Storage"
-                },
-		"/downloads": {
-                    "description": "Choose a Share for nzbhydra downloads. Eg: create a Share called nzbhydra-downloads for this purpose alone.",
-                    "label": "Download Storage"
+                    },
+                    "/downloads": {
+                        "description": "Choose a Share for nzbhydra downloads. Eg: create a Share called nzbhydra-downloads for this purpose alone.",
+                        "label": "Download Storage"
                     }
                 },
                 "environment": {
                     "PUID": {
-		        "description": "Enter a valid UID to run nzbhydra as. It must have full permissions to all Shares mapped in the previous step.",
+                        "description": "Enter a valid UID to run nzbhydra as. It must have full permissions to all Shares mapped in the previous step.",
                         "label": "UID to run nzbhydra as.",
                         "index": 1
-		},
+                    },
                     "PGID": {
                         "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
                         "label": "GID to run nzbhydra as.",
@@ -37,12 +37,12 @@
                 }
             }
         },
-        "description": "NZBHydra is a meta search for NZB indexers.",
+        "description": "NZBHydra is a meta search for NZB indexers. <p><strong>Important</strong>The docker image used by this rock-on has been deprecated by its authors and will thus be removed from Rockstor in the near future. We recommend you to use the NZBHydra2 rock-on instead.</p>",
         "ui": {
             "slug": ""
         },
         "volume_add_support": true,
-	"website": "https://hub.docker.com/r/linuxserver/hydra/",
-	"version": "1.0"
+        "website": "https://hub.docker.com/r/linuxserver/hydra/",
+        "version": "1.0"
     }
 }

--- a/NZBHydra2.json
+++ b/NZBHydra2.json
@@ -1,0 +1,48 @@
+{
+    "NZBHydra2": {
+        "containers": {
+            "nzbhydra2": {
+                "image": "linuxserver/nzbhydra2",
+                "launch_order": 1,
+                "ports": {
+                    "5075": {
+                        "description": "NZBHydra2 WebUI port. Suggested default: 5075",
+                        "host_default": 5075,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for NZBHydra2 configuration. Eg: create a Share called nzbhydra-config for this purpose alone.",
+                        "label": "Config Storage"
+                    },
+                    "/downloads": {
+                        "description": "Choose a Share for NZBHydra downloads. Eg: create a Share called nzbhydra-downloads for this purpose alone.",
+                        "label": "Download Storage"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid UID to run nzbhydra as. It must have full permissions to all Shares mapped in the previous step.",
+                        "label": "UID to run nzbhydra as.",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID to run nzbhydra as.",
+                        "index": 2
+                    }
+                }
+            }
+        },
+        "description": "NZBHydra2 is a meta search for NZB indexers. <p>Uses custom docker image by <a href='https://www.linuxserver.io/' target='_blank'>Linuxserver.io</a>: <a href='https://hub.docker.com/r/linuxserver/nzbhydra2/' target='_blank'>https://hub.docker.com/r/linuxserver/nzbhydra2/</a>, available for amd64, arm32v7 and arm64v8.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "website": "https://hub.docker.com/r/linuxserver/nzbhydra2/",
+        "version": "1.0"
+    }
+}

--- a/NZBHydra2.json
+++ b/NZBHydra2.json
@@ -5,11 +5,10 @@
                 "image": "linuxserver/nzbhydra2",
                 "launch_order": 1,
                 "ports": {
-                    "5075": {
-                        "description": "NZBHydra2 WebUI port. Suggested default: 5075",
-                        "host_default": 5075,
+                    "5076": {
+                        "description": "NZBHydra2 WebUI port. Suggested default: 5076",
+                        "host_default": 5076,
                         "label": "WebUI port",
-                        "protocol": "tcp",
                         "ui": true
                     }
                 },
@@ -26,12 +25,12 @@
                 "environment": {
                     "PUID": {
                         "description": "Enter a valid UID to run nzbhydra as. It must have full permissions to all Shares mapped in the previous step.",
-                        "label": "UID to run nzbhydra as.",
+                        "label": "UID to run NZBHydra as.",
                         "index": 1
                     },
                     "PGID": {
-                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
-                        "label": "GID to run nzbhydra as.",
+                        "description": "Enter a valid GID to use along with the above UID. It (or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID to run NZBHydra as.",
                         "index": 2
                     }
                 }

--- a/root.json
+++ b/root.json
@@ -46,6 +46,7 @@
     "Node-Red": "nodered.json",
     "NZBGet": "nzbget.json",
     "NZBHydra": "NZBHydra.json",
+    "NZBHydra2": "NZBHydra2.json",
     "Ombi": "ombi.json",
     "OpenVPN": "openvpn.json",
     "OwnCloud": "owncloud.json",


### PR DESCRIPTION
When looking at the pages on the Docker Hub for [linuxserver.io/hydra](https://hub.docker.com/r/linuxserver/hydra/), it mentions in the Application Setup section that that image is deprecated, pointing the user to [linuxserver/nzbhydra2](https://hub.docker.com/r/linuxserver/nzbhydra2) instead. I have been using a self-defined image for NZBHydra2 for some time, so I have tidied up the configuration and shared here.

Note: NZBHydra2 no longer allows you to import you existing NZBHydra configuration.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: linuxserver.io NZBHydra2
- website: https://github.com/theotherp/nzbhydra2
- description: NZBHydra2 is meta search application for NZB indexers, offering a unified search experience over several different indexers, it can also integrate into your usenet client. Like many linuxserver.io images, it supports x86_64, arm64v8 and arm32v7 

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/nzbhydra2
- is an official docker image available for this project?: No official image, but linuxserver is in the recommended suppliers of images by the project author.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
