### PR TITLE
Re: Added tautulli rockon to replace deprecated PlexPy rockon.

### DIFF
--- a/root.json
+++ b/root.json
@@ -68,6 +68,7 @@
     "Sonarr": "sonarr.json",
     "Subsonic": "subsonic.json",
     "Syncthing": "syncthing.json",
+    "Tautulli":  "tautulli.json",
     "TeamSpeak3": "teamspeak3.json",
     "TFTP server": "tftpserver.json",
     "Transmission with OpenVPN": "transmission-with-openvpn.json",

--- a/tautulli.json
+++ b/tautulli.json
@@ -1,0 +1,52 @@
+{
+    "Tautulli": {
+        "containers": {
+            "tautulli": {
+                "image": "tautulli/tautulli",
+                "launch_order": 1,
+                "ports": {
+                    "8181": {
+                        "description": "WebUI port. Suggested default: 8181",
+                        "host_default": 8181,
+                        "label": "WebUI port",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for Tautulli configuration. Eg: create a Share called tautulli-config for this purpose alone.",
+                        "label": "Config Storage"
+                    },
+                    "/plex-config": {
+                        "description": "Choose a Share that holds your Plex configuration. This will allow Tautulli to read the Plex log files.",
+                        "label": "Plex Config"
+                    }
+                },
+                "environment": {
+                    "ADVANCED_GIT_BRANCH": {
+                        "description": "Choose branch of Tautulli. unless you know which version to try, just type master",
+                        "label": "GIT_BRANCH",
+                        "index": 1
+                    },
+                    "PUID": {
+                        "description": "Enter a valid UID to run Tautulli with. It must have full permissions to all Shares mapped in the previous step.",
+                        "label": "UID",
+                        "index": 2
+                    },
+                    "PGID": {
+                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID",
+                        "index": 3
+                    }
+                }
+            }
+        },
+        "description": "Tautulli, formerly Plexpy, Is a Python-based Plex Usage tracker.",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "website": "https://hub.docker.com/r/tautulli/tautulli",
+        "version": "1.0"
+    }
+}


### PR DESCRIPTION
Added a Rockon for Tautulli to replace the PlexPy Rockon that is now deprecated.

Fixes # Deprecated PlexPy Rockon.

General information on project
This pull request proposes to add a new rock-on for the following project:

name: Tautulli
website: https://tautulli.com/
description: The only change from the current PlexPy Rockon is using the official Tautulli Docker repo and the relevant names in the descriptions.
Information on docker image
docker image: https://hub.docker.com/r/tautulli/tautulli
is an official docker image available for this project?: Yes.
Checklist
[ * ] Passes JSONlint validation
[ * ] Entry added to root.json in alphabetical order (for new rock-on only)
[ ] "description" object lists and links to the docker image used
[ * ] "description" object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
[ * ] "website" object links to project's main website