### PR TITLE
Adding Calibre Rockon

### DIFF
--- a/calibre.json
+++ b/calibre.json
@@ -1,6 +1,6 @@
 {
-  "Calibre Server": {
-    "description": "Calibre is an open source e-Book management program.<p>The Calibre server allows the management of e-Books across devices.</p>",
+  "Calibre": {
+    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit<a href='https://calibre-ebook.com/'>Calibre's Official Site.</a></p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://calibre-ebook.com/",
@@ -9,7 +9,7 @@
     },
     "volume_add_support": true,
     "containers": {
-      "calibreserver": {
+      "calibre": {
         "image": "linuxserver/calibre",
         "launch_order": 1,
         "opts": [
@@ -27,9 +27,9 @@
             "ui": true
           },
           "8081": {
-            "description": "Calibre HTTPS port?",
+            "description": "Calibre Server port.",
             "host_default": 8081,
-            "label": "HTTPS port",
+            "label": "Server Port",
             "protocol": "tcp",
             "ui": true
           }
@@ -39,20 +39,20 @@
             "description": "Choose a Share for the Calibre configuration data. Eg: create a Share called calibre-config.",
             "label": "Config Storage"
           },
-          "/media": {
-            "description": "Choose a Share with e-Book content. Eg: create a Share called ebook-media for this purpose alone or use an existing share. It will be available as /media. You can also add $,
-            "label": "Media Storage"
+          "/books": {
+            "description": "Choose a Share with e-Book content. Eg: create a Share called ebook-media for this purpose alone or use an existing share. It will be available as /books. You can also add more shares later.",
+            "label": "e-Book Storage"
           }
         },
         "environment": {
           "PUID": {
-            "description": "Enter a valid UID of an existing user with permission to media shares to run Calibre as.",
+            "description": "Enter a valid UID of an existing user with permission to e-Book shares to run Calibre as.",
             "label": "UID",
             "index": 1,
             "default": 1000
           },
           "PGID": {
-            "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre as.",
+            "description": "Enter a valid GID of an existing user with permission to e-Book shares to run Calibre as.",
             "label": "GID",
             "index": 2,
             "default": 1000

--- a/calibre.json
+++ b/calibre.json
@@ -1,6 +1,6 @@
 {
   "Calibre": {
-    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit<a href='https://calibre-ebook.com/'>Calibre's Official Site.</a></p>",
+    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/'>Calibre's Official Site. </a> and <a href='https://hub.docker.com/r/linuxserver/calibre'>the Docker container page.</a></p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://calibre-ebook.com/",

--- a/calibre.json
+++ b/calibre.json
@@ -1,0 +1,64 @@
+{
+  "Calibre Server": {
+    "description": "Calibre is an open source e-Book management program.<p>The Calibre server allows the management of e-Books across devices.</p>",
+    "more_info": "",
+    "version": "0.0.1",
+    "website": "https://calibre-ebook.com/",
+    "ui": {
+      "slug": ""
+    },
+    "volume_add_support": true,
+    "containers": {
+      "calibreserver": {
+        "image": "linuxserver/calibre",
+        "launch_order": 1,
+        "opts": [
+          [
+            "-v",
+            "/config"
+          ]
+        ],
+        "ports": {
+          "8080": {
+            "description": "Calibre WebUI port.",
+            "host_default": 8080,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          },
+          "8081": {
+            "description": "Calibre HTTPS port?",
+            "host_default": 8081,
+            "label": "HTTPS port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/config": {
+            "description": "Choose a Share for the Calibre configuration data. Eg: create a Share called calibre-config.",
+            "label": "Config Storage"
+          },
+          "/media": {
+            "description": "Choose a Share with e-Book content. Eg: create a Share called ebook-media for this purpose alone or use an existing share. It will be available as /media. You can also add $,
+            "label": "Media Storage"
+          }
+        },
+        "environment": {
+          "PUID": {
+            "description": "Enter a valid UID of an existing user with permission to media shares to run Calibre as.",
+            "label": "UID",
+            "index": 1,
+            "default": 1000
+          },
+          "PGID": {
+            "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre as.",
+            "label": "GID",
+            "index": 2,
+            "default": 1000
+          }
+        }
+      }
+    }
+  }
+}

--- a/calibre.json
+++ b/calibre.json
@@ -1,6 +1,6 @@
 {
   "Calibre": {
-    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/' target='_blank' rel='noopener noreferrer'>Calibre's Official Site</a> and <a href='https://hub.docker.com/r/linuxserver/calibre' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p>",
+    "description": "Calibre is an open source e-Book management program, allowing for the management of e-Books and syncing across devices using the content server. This Rock-On is compatible with x86_64/amd64 machines only.</p><p>For more information visit <a href='https://calibre-ebook.com/' target='_blank' rel='noopener noreferrer'>Calibre's Official Site</a>.</p><p><p>Based on the docker image provided by Linuxserver.io: <a href='https://hub.docker.com/r/linuxserver/calibre' target='_blank' rel='noopener noreferrer'>https://hub.docker.com/r/linuxserver/calibre'</a>.</p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://calibre-ebook.com/",

--- a/calibre.json
+++ b/calibre.json
@@ -1,6 +1,6 @@
 {
   "Calibre": {
-    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/' target='_blank' rel='noopener noreferrer'>Calibre's Official Site. </a> and <a href='https://hub.docker.com/r/linuxserver/calibre' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p>",
+    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/' target='_blank' rel='noopener noreferrer'>Calibre's Official Site</a> and <a href='https://hub.docker.com/r/linuxserver/calibre' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://calibre-ebook.com/",

--- a/calibre.json
+++ b/calibre.json
@@ -1,6 +1,6 @@
 {
   "Calibre": {
-    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/'>Calibre's Official Site. </a> and <a href='https://hub.docker.com/r/linuxserver/calibre'>the Docker container page.</a></p>",
+    "description": "Calibre is an open source e-Book management program.<p>Calibre allows for the management of e-Books and syncing across devices using the content server.</p><p>For more information visit <a href='https://calibre-ebook.com/' target='_blank' rel='noopener noreferrer'>Calibre's Official Site. </a> and <a href='https://hub.docker.com/r/linuxserver/calibre' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://calibre-ebook.com/",

--- a/calibre.json
+++ b/calibre.json
@@ -12,12 +12,6 @@
       "calibre": {
         "image": "linuxserver/calibre",
         "launch_order": 1,
-        "opts": [
-          [
-            "-v",
-            "/config"
-          ]
-        ],
         "ports": {
           "8080": {
             "description": "Calibre WebUI port.",
@@ -31,7 +25,7 @@
             "host_default": 8081,
             "label": "Server Port",
             "protocol": "tcp",
-            "ui": true
+            "ui": false
           }
         },
         "volumes": {
@@ -55,7 +49,7 @@
             "description": "Enter a valid GID of an existing user with permission to e-Book shares to run Calibre as.",
             "label": "GID",
             "index": 2,
-            "default": 1000
+            "default": 100
           }
         }
       }

--- a/root.json
+++ b/root.json
@@ -2,6 +2,7 @@
     "Bitcoin": "bitcoind.json",
     "Bitwarden-rs": "bitwarden-rs-alpine.json",
     "Booksonic": "booksonic.json",
+    "Calibre":  "calibre.json",
     "Cardigann": "cardigann.json",
     "Collabora Online": "collabora-online.json",
     "COPS": "cops.json",


### PR DESCRIPTION
Fixes # N/A

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Calibre
- website: https://calibre-ebook.com/
- description: Calibre is an e-Book management tool that allows syncing to devices using a built in server.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/calibre
- is an official docker image available for this project?: No


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
