### PR TITLE
Adding Rockon for Calibre-web

### DIFF
--- a/calibre-web.json
+++ b/calibre-web.json
@@ -41,7 +41,7 @@
         },
         "environment": {
           "PUID": {
-            "description": "Enter a valid UID of an existing user with permission to media shares to run Calibre as.",
+            "description": "Enter a valid UID of an existing user with permission to media shares to run Calibre-web as.",
             "label": "UID",
             "index": 1,
             "default": 1000

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,6 +1,6 @@
 {
   "Calibre Web": {
-    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration in the WebUI.",
+    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web' target='_blank' rel='noopener noreferrer'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration in the WebUI.",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://github.com/janeczku/calibre-web",

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -47,7 +47,7 @@
             "default": 1000
           },
           "PGID": {
-            "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre as.",
+            "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre-web as.",
             "label": "GID",
             "index": 2,
             "default": 1000

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,7 +1,7 @@
 {
   "Calibre Web": {
     "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p><strong><em>Note:</em></strong> if using the Calibre Rock-On as database, select the same share used as Media Storage as for the Calibre Rock-On.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web' target='_blank' rel='noopener noreferrer'>the official Github page</a>. Based on the image provided by Linuxserver.io: <a href='https://hub.docker.com/r/linuxserver/calibre-web' target='_blank' rel='noopener noreferrer'>https://hub.docker.com/r/linuxserver/calibre-web</a>, available for x86-64/amd64, armhf/arm32v7, and arm64/arm64v8.</p>",
-    "more_info": "",
+    "more_info": "<h4>Using Calibre-web in combination with the Calibre Rock-On</h4><p>Calibre-web needs access to your E-books library and Calibre database file used by the Calibre Rock-On. To do so, during the Calibre-web Rock-On installation wizard, make sure to choose the same shares used for media and Calibre config for <em>Media Storage</em> and <em>Config Storage</em> as the ones chosen for the Calibre Rock-on.</p><h4>First login configuration</h4><p>On the initial Calibre-web setup screen, enter <code>/books</code> as your calibre library location and <code>/config/Calibre Library</code> as the Calibre database location.</p><p>The default admin login username is <code>admin</code>, and its password is <code>admin123</code>.</p>",
     "version": "0.0.1",
     "website": "https://github.com/janeczku/calibre-web",
     "ui": {

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -50,7 +50,7 @@
             "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre-web as.",
             "label": "GID",
             "index": 2,
-            "default": 1000
+            "default": 100
           }
         }
       }

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,6 +1,6 @@
 {
   "Calibre Web": {
-    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration.",
+    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration in the WebUI.",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://github.com/janeczku/calibre-web",

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -27,7 +27,7 @@
             "label": "Config Storage"
           },
           "/books": {
-            "description": "Choose the Share with e-Book content. Eg: Select the share where Calibre reads ebooks from. It will be available as /media. You can also add more shares later.<p>If using the Calibre Rockon, you must select the same shares that were used when configuring that rockon or the books will not be accessible.</p>",
+            "description": "Choose the Share with e-Book content. If using the Calibre Rock-On, you must select the same share that was used for its media storage.  It will be linked under /media.",
             "label": "Media Storage"
           }
         },

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,6 +1,6 @@
 {
   "Calibre Web": {
-    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web' target='_blank' rel='noopener noreferrer'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web' target='_blank' rel='noopener noreferrer'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration in the WebUI.",
+    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p><strong><em>Note:</em></strong> if using the Calibre Rock-On as database, select the same share used as Media Storage as for the Calibre Rock-On.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web' target='_blank' rel='noopener noreferrer'>the official Github page</a>. Based on the image provided by Linuxserver.io: <a href='https://hub.docker.com/r/linuxserver/calibre-web' target='_blank' rel='noopener noreferrer'>https://hub.docker.com/r/linuxserver/calibre-web</a>, available for x86-64/amd64, armhf/arm32v7, and arm64/arm64v8.</p>",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://github.com/janeczku/calibre-web",

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -12,14 +12,6 @@
       "calibreWeb": {
         "image": "linuxserver/calibre-web",
         "launch_order": 1,
-        "opts": [
-          [
-            "-v",
-            "/config",
-            "-v",
-            "/books"
-          ]
-        ],
         "ports": {
           "8083": {
             "description": "Calibre-web UI port.",

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,0 +1,59 @@
+{
+  "Calibre Web": {
+    "description": "Calibre Web is an open source web interface for the e-Book management program Calibre.<p>The Web interface allows user logins and the management of e-Books through a clean web interface.</p></br>During initial configuration, use the directory '/config/Calibre Library' as your database location.",
+    "more_info": "",
+    "version": "0.0.1",
+    "website": "https://github.com/janeczku/calibre-web",
+    "ui": {
+      "slug": ""
+    },
+    "volume_add_support": true,
+    "containers": {
+      "calibreWeb": {
+        "image": "linuxserver/calibre-web",
+        "launch_order": 1,
+        "opts": [
+          [
+            "-v",
+            "/config",
+            "-v",
+            "/books"
+          ]
+        ],
+        "ports": {
+          "8083": {
+            "description": "Calibre-web UI port.",
+            "host_default": 8083,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/config": {
+            "description": "Choose the Share where you store Calibre configuration data. Eg: The Share called calibre-config.",
+            "label": "Config Storage"
+          },
+          "/books": {
+            "description": "Choose the Share with e-Book content. Eg: Select the share where Calibre reads ebooks from. It will be available as /media. You can also add more shares later.",
+            "label": "Media Storage"
+          }
+        },
+        "environment": {
+          "PUID": {
+            "description": "Enter a valid UID of an existing user with permission to media shares to run Calibre as.",
+            "label": "UID",
+            "index": 1,
+            "default": 1000
+          },
+          "PGID": {
+            "description": "Enter a valid GID of an existing user with permission to media shares to run Calibre as.",
+            "label": "GID",
+            "index": 2,
+            "default": 1000
+          }
+        }
+      }
+    }
+  }
+}

--- a/calibre-web.json
+++ b/calibre-web.json
@@ -1,6 +1,6 @@
 {
   "Calibre Web": {
-    "description": "Calibre Web is an open source web interface for the e-Book management program Calibre.<p>The Web interface allows user logins and the management of e-Books through a clean web interface.</p></br>During initial configuration, use the directory '/config/Calibre Library' as your database location.",
+    "description": "Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.<p>The Web interface allows user logins and the management and download of e-Books through a clean web interface.</p><p>For more information please see <a href='https://github.com/janeczku/calibre-web'>the oficial Github page</a> and <a href='https://hub.docker.com/r/linuxserver/calibre-web'>the Docker container page.</a></p></br>If linking to the Calibre Rockon use the directory '/config/Calibre Library' as your database location during configuration.",
     "more_info": "",
     "version": "0.0.1",
     "website": "https://github.com/janeczku/calibre-web",
@@ -31,11 +31,11 @@
         },
         "volumes": {
           "/config": {
-            "description": "Choose the Share where you store Calibre configuration data. Eg: The Share called calibre-config.",
+            "description": "Choose the Share where you store Calibre configuration data. Eg: The Share called calibre-config.<p>If using the Calibre rockon, this must be the configuration share of Calibre.  When configuring Calibre-Web, use '/config/Calibre Library' as the database location.</p>",
             "label": "Config Storage"
           },
           "/books": {
-            "description": "Choose the Share with e-Book content. Eg: Select the share where Calibre reads ebooks from. It will be available as /media. You can also add more shares later.",
+            "description": "Choose the Share with e-Book content. Eg: Select the share where Calibre reads ebooks from. It will be available as /media. You can also add more shares later.<p>If using the Calibre Rockon, you must select the same shares that were used when configuring that rockon or the books will not be accessible.</p>",
             "label": "Media Storage"
           }
         },

--- a/root.json
+++ b/root.json
@@ -2,6 +2,7 @@
     "Bitcoin": "bitcoind.json",
     "Bitwarden-rs": "bitwarden-rs-alpine.json",
     "Booksonic": "booksonic.json",
+    "Calibre Web":  "calibre-web.json",
     "Cardigann": "cardigann.json",
     "Collabora Online": "collabora-online.json",
     "COPS": "cops.json",


### PR DESCRIPTION
Fixes # N/A

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Calibre-web
- website: https://github.com/janeczku/calibre-web
- description: This container creates a Calibre-Web server that is a clean e-Book management server.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/calibre-web
- is an official docker image available for this project?: Yes
 [Official](https://hub.docker.com/r/technosoft2000/calibre-web) and [linuxserver](https://hub.docker.com/r/linuxserver/calibre-web) container both listed on their Github.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
