### PR TITLE
SiliconDust's HdHomerun standalone DVR engine Rockon 

### DIFF
--- a/hdhomerun_dvr.json
+++ b/hdhomerun_dvr.json
@@ -1,0 +1,47 @@
+{
+  "HDHomeRun DVR Engine": {
+    "containers": {
+      "hdhomerun_dvr_engine": {
+        "image": "jackdock96/hdh_dvr",
+        "opts": [
+          [
+            "--net=host",
+            ""
+          ]
+        ],
+        "launch_order": 1,
+        "volumes": {
+          "/dvrdata": {
+            "description": "Choose a Share for HomeRun DVR engine configuration. E.g.: create a Share called hdh-config for this purpose alone. It is important that the owner/group specified later have full access to the share (R/W/E). Recommended size is a few MB if quotas are used",
+            "label": "Config Storage"
+          },
+          "/dvrrec": {
+            "description": "Choose a Share for storing the DVR recordings and the Live TV stream buffering (for pausing). E.g.: create a Share called hdh-rec for this purpose alone. This share needs to have full (R/W/E) access for the user and group specified later. If the recordings are to be managed/organized by another Rockon, e.g. Plex or jellyfin, ensure that the User/Group matches theirs.",
+            "label": "Data Storage"
+          }
+        },
+        "environment": {
+          "VERSION": {
+            "description": "Choose version of plex: Unless you know which version to try, just type latest",
+            "label": "VERSION",
+            "index": 1
+          },
+          "PUID": {
+            "description": "Enter a valid UID to run the HDHomeRun DVR engine with. It must have full permissions to all Shares mapped in the previous step.",
+            "label": "UID",
+            "index": 2
+          },
+          "PGID": {
+            "description": "Enter a valid GID to use along with the above UID. It (or the above UID) must have full permissions to all Shares mapped in the previous step.",
+            "label": "GID",
+            "index": 3
+          }
+        }
+      }
+    },
+    "description": "Dockerized version of the HDHomeRun DVR program. Requires recent HDHomeRun hardware and DVR subscription for discovery and recording enablement.<p>Based on a custom docker image: <a href='https://hub.docker.com/r/jackdock96/hdh_dvr' target='_blank'>https://hub.docker.com/r/jackdock96/hdh_dvr</a>.</p><p> Currently only supporting amd64 architecture",
+    "more_info": "Your HDHomerun DVR subscription must be activated as documented in the Silicondust Forum. All rules and policies from Silicondust must be followed. For enabling the use of the beta version of the recording engine, change the 'BetaEngine' flag in the dvr.conf file after the first Rockon start.  If using an existing share but planning on posting recordings to a specific directory, add the sub-folder to the dvr.conf file RecordingPath (but keep the first folder name as is). For each change to the dvr.conf file restart the Rockon. Port 65001 (udp/tcp) will be used for discovery, and udp ports 5002 and 5004 for recording and buffering. This version will utilize the host network stack, due to dynamic port assignments by the engine at this time.",
+    "website": "https://silicondust.com",
+    "version": "1.0"
+  }
+}

--- a/root.json
+++ b/root.json
@@ -22,6 +22,7 @@
     "Gollum": "gollum.json",
     "HAProxy-Letsencrypt": "haproxy-letsencrypt.json",
     "HandBrake": "handbrake.json",
+	"HDHomeRun DVR Engine": "hdhomerun_dvr.json"
     "Headphones": "headphones.json",
     "Home Assistant": "home-assistant.json",
     "HTTP to HTTPS redirect": "redirect-http-to-https.json",


### PR DESCRIPTION

Fixes #278  .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: HDHomeRun DVR engine from SiliconDust
- website: https://www.silicondust.com
- description: standalone DVR engine that work in conjunction with SiliconDust's HDHomeRun series of tuners that don't have the DVR built-in. Requires a valid subscription and recent HDHomeRun hardware

### Information on docker image
- docker image: https://hub.docker.com/repository/docker/jackdock96/hdh_dvr
- is an official docker image available for this project?: Not at this time. I created this docker image to self-update with the latest engine and also offer multi-arch images to support Rockstor's direction of installing on ARM architecture systems, so the docker container doesn't have to be maintained in the repository too frequently.
- **Note**: because the dvr engine uses multi-cast the Rockon is currently configured to use the `net=host` option. Unless one implements a `macvlan` or uses tools like pipework, multi-cast from LAN to container and vice-versa is not possible. I assume, Rockstor's Rocknet might be able to achieve that, but until we are completely cutover to 4.x on OpenSuse, this is the only option.
- Plan is to switch to an official image if/when it becomes available


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
