### PR TITLE
Logitech Media Server (Squeezebox), move to latest release tag

### DIFF
--- a/lms_latest.json
+++ b/lms_latest.json
@@ -1,0 +1,54 @@
+{
+	"Logitech Media Server - Latest Stable": {
+		"description": "Logitech Media Server (aka Squeezebox, slimserver, etc.). Latest stable version. For future updates see more information icon after first installation<p>Uses custom docker image: <a href='https://hub.docker.com/r/doliana/logitech-media-server' target='_blank'>https://hub.docker.com/r/doliana/logitech-media-server</a>. Available for amd64, arm/v7 &arm64 architecture.",
+		"more_info": "<h4>Update to newer version</h4><p>After first installation: to update to a newer stable version, either uninstall/reinstall the Rockon or use the Watchtower Rockon to manage the update of the underlying Media Server image, as it does not automatically update itself during a stop/restart of the Rockon like some other Rockons do. Don't use the update option within the LMS!</p><p>The LMS configuration files will remain in place on the volumes that were specified during the initial installation</p>",
+		"website": "https://mysqueezebox.com/",
+		"version": "2.2",
+		"ui": {
+			"slug": ""
+		},
+		"containers": {
+			"lms8": {
+				"image": "doliana/logitech-media-server",
+				"tag": "latest",
+				"launch_order": 1,
+				"opts": [
+					[
+						"--net",
+						"host"
+					]
+				],
+				"ports": {
+					"9000": {
+						"description": "WebUI port. Suggested default: 9000",
+						"host_default": 9000,
+						"label": "WebUI port",
+						"protocol": "tcp",
+						"ui": true
+					},
+					"9090": {
+						"description": "Command Line Interface (used for example by Android app Squeezer). Suggested Default: 9090",
+						"host_default": 9090,
+						"label": "CLI port",
+						"protocol": "tcp"
+					},
+					"3483": {
+						"description": "control channel for LMS (display, IR, etc.), tcp and udp (SB --> Slimserver discovery and for older SLIMP3 players). Suggested Default: 3483",
+						"host_default": 3483,
+						"label": "Control Channel"
+					}
+				},
+				"volumes": {
+					"/srv/squeezebox": {
+						"description": "Choose a Share for LMS configuration. E.g.: create a Share called lms-config for this purpose alone.",
+						"label": "Config Storage"
+					},
+					"/srv/music": {
+						"description": "Choose a Share for LMS content(your media). E.g.: create a Share called lms-music for this purpose alone. You can also assign other media Shares on the system after installation.",
+						"label": "Data Storage"
+					}
+				}
+			}
+		}
+	}
+}

--- a/lms_latest.json
+++ b/lms_latest.json
@@ -8,7 +8,7 @@
 			"slug": ""
 		},
 		"containers": {
-			"lms8": {
+			"lms_latest": {
 				"image": "doliana/logitech-media-server",
 				"tag": "latest",
 				"launch_order": 1,

--- a/root.json
+++ b/root.json
@@ -32,6 +32,7 @@
     "Koel": "koel.json",
     "LazyLibrarian": "lazylibrarian.json",
     "Logitech Squeezebox 7.9.4": "LogitechSqueezebox-7.9.4.json",
+    "Logitech Media Server - Latest Stable": "lms_latest.json",
     "MariaDB": "mariadb.json",
     "Medusa": "medusa.json",
     "Minecraft": "minecraft.json",


### PR DESCRIPTION
Fixes #282.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Logitech Media Server
- website: https://mysqueezebox.com
- description: Replace current 7.9.4 LMS Rockon with one that uses "latest" label, so upon installation the latest stable version of LMS is pulled, instead of being pinned to an aging version number. Once this is accepted/merged the older version would be deprecated.

### Information on docker image
- docker image: https://hub.docker.com/r/doliana/logitech-media-server
- is an official docker image available for this project?: No, however this is a popular docker container (10+M pulls) and also used in the already existing Rockon. This newer version will also add some more explanation for updating in the More Info tag.
- this still requires the `net=host` option, because some of the plug-ins require multi-cast (e.g. the apple bridge, as well as some of the other plugins). Once docker is capable of routing multi-cast correctly, this option can be dropped. Alternatively, once Rockstor is completely migrated to OpenSuse, the Rocknet might be able to support this. If so, then we can change/update this one (as well as others without the host network option), but it will make installation also more involved ...


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
