### PR TITLE
Add Traefik

### DIFF
--- a/root.json
+++ b/root.json
@@ -73,6 +73,7 @@
     "Tautulli": "tautulli.json",
     "TeamSpeak3": "teamspeak3.json",
     "TFTP server": "tftpserver.json",
+    "Traefik": "traefik.json",
     "Transmission with OpenVPN": "transmission-with-openvpn.json",
     "Transmission": "transmission.json",
     "Ubiquiti Unifi linuxserver.io": "unifi-linuxserver.json",

--- a/traefik.json
+++ b/traefik.json
@@ -1,0 +1,45 @@
+{
+  "Traefik": {
+    "description": "Traefik is an open-source Edge Router that makes publishing your services a fun and easy experience. It receives requests on behalf of your system and finds out which components are responsible for handling them.",
+    "version": "1",
+    "website": "https://doc.traefik.io/traefik/",
+    "icon": "https://doc.traefik.io/traefik/assets/images/logo-traefik-proxy-logo.svg",
+    "ui": {"slug": ""},
+    "containers": {
+      "traefik": {
+        "image": "traefik",
+        "launch_order": "1",
+        "ports": {
+          "80": {
+            "description": "HTTP (Unsecure) Port",
+            "label": "HTTP Port",
+            "host_default": 80,
+            "protocol": "tcp"
+          },
+          "443": {
+            "description": "HTTPS (Secure) Port",
+            "label": "HTTPS Port",
+            "host_default": 443,
+            "protocol": "tcp"
+          },
+          "8080": {
+            "description": "Traefik Dashboard",
+            "label": "Dashboard Port",
+            "host_default": 8080,
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/etc/traefik": {
+            "description": "Traefik configuration directory. You can place a traefik.yml or traefik.toml in this share to configure Traefik",
+            "label": "Configuration"
+          }
+        },
+        "opts": [ ["-v", "/var/run/docker.sock:/var/run/docker.sock"] ],
+        "cmd_arguments": [ ["--api.insecure=true", "--providers.docker"] ],
+        "devices": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://traefik.io/traefik/

Traefik is a incredibly customizable reverse proxy, including support for auto-mapping other docker containers. I use a traefik.toml like follows, to auto map all containers to subdomains

All access is already controlled at my WAF, so I'm leaving authentication to the user

```toml
[api]
  dashboard = true
  insecure = true

[entryPoints]
  [entryPoints.web]
    address = ":80"

  [entryPoints.websecure]
    address = ":443"

[http.routers.traefik]
  rule = "Host(`traefik.my.domain.tld`)"
  service = "api@internal"

[providers.docker]  # Set up docker discovery
  defaultRule = "Host(`{{ .Name }}.my.domain.tld`)"
```

The cmd_arguments used are a minimum to get traefik to expose a dashboard and discover docker containers.

> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes # .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name:
- website:
- description: <brief description of the project and how it intergrates with Rockstor>

### Information on docker image
- docker image: <link to image page on docker hub>
- is an official docker image available for this project?: 


### Checklist
- [ ] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [ ] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [ ] `"website"` object links to project's main website
