### PR TITLE
Add a virtual machine host rockon using libvirtd

### DIFF
--- a/root.json
+++ b/root.json
@@ -78,6 +78,7 @@
     "Ubiquiti Unifi linuxserver.io": "unifi-linuxserver.json",
     "Unifi Controller": "unifi.json",
     "uTorrent": "uTorrent.json",
+    "virt-manager": "virt-manager.json",
     "Watchtower offical": "watchtower_official.json",
     "Xeoma Video Surveillance": "xeoma.json",
     "YouTrack official": "youtrack-official.json",

--- a/virt-manager.json
+++ b/virt-manager.json
@@ -1,0 +1,69 @@
+{
+  "virt-manager": {
+    "description": "An interface for managing virtual machines through libvirt. This Rock-on runs libvirtd in docker in one container, and exposes a HTML5 WebUI using GTK+ Broadway with no need for remote desktop or special viewer software",
+    "ui": {
+      "slug": ""
+    },
+    "volume_add_support": true,
+    "website": "https://github.com/m-bers/docker-virt-manager",
+    "version": "1.0",
+    "containers": {
+      "libvirtd": {
+        "image": "xtruder/libvirtd",
+        "launch_order": 1,
+        "opts": [
+          ["--cap-add", "NET_ADMIN"],
+          ["--cap-add", "SYS_ADMIN"],
+          ["--cap-add", "SYS_NICE"],
+          ["--cap-add", "SYS_RAWIO"],
+          ["--device", "/dev/kvm"],
+          ["--device", "/dev/mem"],
+          ["--device", "/dev/net/tun"],
+          ["--security-opt", "apparmor=unconfined"],
+          ["-v", "/dev/serial:/dev/serial"],
+          ["-v", "/run/libvirt:/run/libvirt"],
+          ["-v", "/sys/bus/usb:/sys/bus/usb"],
+          ["-v", "/sys/fs/cgroup:/sys/fs/cgroup:rw"]
+        ],
+        "ports": {
+          "16509": {
+            "description": "libvirt port",
+            "host_default": 16509,
+            "label": "libvirt"
+          },
+          "22": {
+            "description": "SSH port",
+            "host_default": 10022,
+            "label": "SSH"
+          },
+          "5900": {
+            "description": "VNC port",
+            "host_default": 15900,
+            "label": "VNC"
+          }
+        },
+        "volumes": {
+          "/etc/libvirt/qemu": {"description": "Libvirt config store", "label": "libvirt configuration"},
+          "/var/lib/libvirt": {"description": "Libvirt data store", "label": "libvirt storage"}
+        }
+      },
+      "virt-manager": {
+        "image": "mber5/virt-manager",
+        "launch_order": 2,
+        "opts": [
+          ["-e", "HOSTS=['qemu:///system']"],
+          ["-v", "/run/libvirt:/run/libvirt"]
+        ],
+        "ports": {
+          "80": {
+            "description": "virt-manager html5 port. Suggested default: 8185",
+            "host_default": 8185,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This rockon runs libvirtd in docker, using KVM. 

This requires host processor support, you can check for support with `grep -E '(vmx|svm)' /proc/cpuinfo`. 
You also need nested virtualization support, Rockstor seemed to already have this enabled for `kvm_intel`, but it could be guaranteed with the kernel cmdline `kvm-intel.nested=1 kvm-amd.nested=1`. 

Completely untested, but ARM hosts could work as well. I don't have any relevant hardware to test on though.

Using virt-manager can be a little "crunchy" sometimes, pasting into VMs is nigh-impossible right now.

I'd like some other people to test this, but it works for me.

I'm uncertain how some of the checklist here should be handled, I figure I would open this to discussion

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: virt-manager
- website: https://libvirt.org
- description: A virtual machine host and web interface

### Information on docker image
- docker image: https://hub.docker.com/r/hrishikesh/libvirtd, https://hub.docker.com/r/mber5/virt-manager
- is an official docker image available for this project?: not really

### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [ ] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
 