### PR TITLE
Update Owncloud Image Version

### DIFF
--- a/owncloudHTTPS.json
+++ b/owncloudHTTPS.json
@@ -2,7 +2,7 @@
 "owncloudHTTPS": {
         "containers": {
             "owncloudHTTPS": {
-                "image": "owncloud",
+                "image": "owncloud/server",
                 "launch_order": 1,
                 "ports": {
                     "443": {


### PR DESCRIPTION
Fixes # .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: onwcloud HTTPS
- website: https://owncloud.com/es/
- description: The image "owncloud" is deprecated on Docker Hub, updating the image with "owncloud/server"  the community could get the latest version available in easy way. 
 
### Information on docker image
- docker image: https://hub.docker.com/_/owncloud
- is an official docker image available for this project?: Yes


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
