### PR TITLE
Web Services Discovery Daemon (Wsdd) rockon

### DIFF
--- a/root.json
+++ b/root.json
@@ -82,6 +82,7 @@
     "Unifi Controller": "unifi.json",
     "uTorrent": "uTorrent.json",
     "Watchtower offical": "watchtower_official.json",
+    "Web Service Discovery (wsdd) For Windows Networks": "wsdd.json",
     "Xeoma Video Surveillance": "xeoma.json",
     "YouTrack official": "youtrack-official.json",
     "Zabbix-XXL": "zabbix-xxl.json",

--- a/root.json
+++ b/root.json
@@ -82,7 +82,7 @@
     "Unifi Controller": "unifi.json",
     "uTorrent": "uTorrent.json",
     "Watchtower offical": "watchtower_official.json",
-    "Web Service Discovery (wsdd) For Windows Networks": "wsdd.json",
+    "Web Service Discovery For Windows Networks": "wsdd.json",
     "Xeoma Video Surveillance": "xeoma.json",
     "YouTrack official": "youtrack-official.json",
     "Zabbix-XXL": "zabbix-xxl.json",

--- a/wsdd.json
+++ b/wsdd.json
@@ -25,7 +25,7 @@
         }
       }
     },
-    "description": "A simple container for Linux systems running samba, so that Windows 10 version 1511 or higher will display the Rockstor host in the Network folder.<p>This version is geared towards local network workgroup setups only.</p><p>Based on the custom docker image: <a href='https://hub.docker.com/r/kosdk/wsdd target=_blank> https://hub.docker.com/r/kosdk/wsdd</a>, available for amd64, arm32v7 and arm64v8.</p>",
+    "description": "A simple container for Linux systems running samba, so that Windows 10 version 1511 or higher will display the Rockstor host in the Network folder.<p>This version is geared towards local network workgroup setups only.</p><p>Based on the custom docker image: <a href='https://hub.docker.com/r/kosdk/wsdd' target='_blank'> https://hub.docker.com/r/kosdk/wsdd</a>, available for amd64, arm32v7 and arm64v8.</p>",
     "ui": {
       "https": false,
       "slug": ""

--- a/wsdd.json
+++ b/wsdd.json
@@ -1,5 +1,5 @@
 {
-  "Web Service Discovery (wsdd) For Windows Networks": {
+  "Web Service Discovery For Windows Networks": {
     "containers": {
       "wsdd_daemon": {
         "image": "kosdk/wsdd",

--- a/wsdd.json
+++ b/wsdd.json
@@ -17,7 +17,7 @@
             "index": 1
           },
           "WORKGROUP": {
-            "description": "Set the workgroup name.",
+            "description": "Set the workgroup name. This should be the same name used during the setup of the Samba service on the Rockstor appliance",
             "label": "Work group",
             "default": "WORKGROUP",
             "index": 2

--- a/wsdd.json
+++ b/wsdd.json
@@ -1,0 +1,36 @@
+{
+  "Web Service Discovery (wsdd) For Windows Networks": {
+    "containers": {
+      "wsdd_daemon": {
+        "image": "kosdk/wsdd",
+        "opts": [
+          [
+            "--net=host",
+            ""
+          ]
+        ],
+        "launch_order": 1,
+        "environment": {
+          "HOST_NAME": {
+            "description": "Set the host name Rockstor uses.",
+            "label": "Host Name",
+            "index": 1
+          },
+          "WORKGROUP": {
+            "description": "Set the workgroup name.",
+            "label": "Work group",
+            "default": "WORKGROUP",
+            "index": 2
+          }
+        }
+      }
+    },
+    "description": "A simple container for Linux systems running samba, so that Windows 10 version 1511 or higher will display the Rockstor host in the Network folder.<p>This version is geared towards local network workgroup setups only.</p><p>Based on the custom docker image: <a href='https://hub.docker.com/r/kosdk/wsdd target=_blank> https://hub.docker.com/r/kosdk/wsdd</a>, available for amd64, arm32v7 and arm64v8.</p>",
+    "ui": {
+      "https": false,
+      "slug": ""
+    },
+    "website": "https://hub.docker.com/r/kosdk/wsdd",
+    "version": "1.0"
+  }
+}


### PR DESCRIPTION
Fixes #295 .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: wsdd (Web Service Discovery Daemon)
- website: based on https://github.com/christgau/wsdd
- description: A container for Linux systems running samba, so that Windows 10 version 1511 or higher will display the host in the Network folder. This rockon setup is only for workgroup based networks, as rockons cannot currently handle either/or selection fields. Due to the nature of the wsdd, this rockon requires the --net=host option.

### Information on docker image
- docker image: https://hub.docker.com/r/kosdk/wsdd
- is an official docker image available for this project?: No. There are more popular ones, but they only offer the amd64 architecture. The one used here allows for arm v7,v8 and amd64 usage and is the most recent of those. Most docker images are similar in available parameters. If there will be a more relevant in the future, it should be easy enough to just replace the image link in the json file.


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
