### PR TITLE
Update for separate API and console ports in MinIO Docker image

### DIFF
--- a/minio.json
+++ b/minio.json
@@ -1,9 +1,9 @@
 {
     "MinIO": {
-        "description": "MinIO is an S3-compatible object storage server. This rock-on requires Rockstor 3.9.2-39 or later and is compatible with x86_64/amd64 machines only.<p>Based on the official MinIO docker image: <a href='https://hub.docker.com/r/minio/minio' target='_blank'>https://hub.docker.com/r/minio/minio</a>.",
-        "version": "1.0",
+        "description": "MinIO is an S3-compatible object storage server.",
+        "version": "1.1",
         "website": "https://minio.io",
-        "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.",
+        "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.  IMPORTANT: Read and understand the MinIO Rock-on documentation concerning port selection before installing this Rock-on.",
         "ui": {
             "https": false,
             "slug": ""
@@ -15,10 +15,15 @@
                 "launch_order": 1,
                 "ports": {
                     "9000": {
-                        "description": "API and Portal access, default 9000",
+                        "description": "Port for API access, default 9000",
                         "host_default": 9000,
-                        "label": "MinIO API and Portal",
-                        "protocol": "tcp",
+                        "label": "MinIO API Port",
+                        "ui": true
+                    },
+                    "9001": {
+                        "description": "Port for Admin Portal access, default 9001",
+                        "host_default": 9001,
+                        "label": "MinIO Admin Portal Port",
                         "ui": true
                     }
                 },
@@ -29,23 +34,20 @@
                     }
                 },
                 "cmd_arguments": [
-                    [
-                        "server",
-                        "/data"
-                    ]
-                ],
+                    [ "server" , "/data" ]
+                 ],
                 "environment": {
-                    "MINIO_ACCESS_KEY": {
-                        "description": "MinIO Access Key (admin username), 1 to 128 alphanumeric characters",
-                        "label": "MinIO Access Key"
+                    "MINIO_ROOT_USER": {
+                        "description": "MinIO Administrator Username, 1 to 128 alphanumeric characters",
+                        "label": "MinIO Admin User"
                     },
-                    "MINIO_SECRET_KEY": {
-                        "description": "MinIO Secret Key (admin password), 1 to 128 alphanumeric characters",
-                        "label": "MinIO Secret Key"
+                    "MINIO_ROOT_PASSWORD": {
+                        "description": "MinIO Administrator Password, 1 to 128 alphanumeric characters",
+                        "label": "MinIO Admin Password"
                     },
-                    "MINIO_BROWSER": {
-                        "description": "Web Portal admin access, on to enable, off to disable",
-                        "label": "Web Portal Access"
+                    "MINIO_CONSOLE_ADDRESS": {
+                        "description": "MinIO Console Address, for example, \":9001\".  Must be the same port as \"MinIO Admin Portal Port\".",
+                        "label": "MinIO Console Address"
                     }
                 }
             }

--- a/minio.json
+++ b/minio.json
@@ -1,6 +1,6 @@
 {
     "MinIO": {
-        "description": "MinIO is an S3-compatible object storage server.",
+        "description": "MinIO is an S3-compatible object storage server.  This Rock-on is based on the official MinIO Docker image <a href='https://hub.docker.com/r/minio/minio' target='_blank'>https://hub.docker.com/r/minio/minio</a>.",
         "version": "1.1",
         "website": "https://minio.io",
         "more_info": "This Rock-on uses the official MinIO Docker image to implement a single MinIO instance with a single object storage share, suitable for use on a private network.  If your connections traverse a network you do not control, consider using a VPN for encryption.  IMPORTANT: Read and understand the MinIO Rock-on documentation concerning port selection before installing this Rock-on.",
@@ -18,7 +18,7 @@
                         "description": "Port for API access, default 9000",
                         "host_default": 9000,
                         "label": "MinIO API Port",
-                        "ui": true
+                        "ui": false
                     },
                     "9001": {
                         "description": "Port for Admin Portal access, default 9001",
@@ -38,11 +38,11 @@
                  ],
                 "environment": {
                     "MINIO_ROOT_USER": {
-                        "description": "MinIO Administrator Username, 1 to 128 alphanumeric characters",
+                        "description": "MinIO Administrator Username, 3 to 128 alphanumeric characters",
                         "label": "MinIO Admin User"
                     },
                     "MINIO_ROOT_PASSWORD": {
-                        "description": "MinIO Administrator Password, 1 to 128 alphanumeric characters",
+                        "description": "MinIO Administrator Password, 8 to 128 alphanumeric characters",
                         "label": "MinIO Admin Password"
                     },
                     "MINIO_CONSOLE_ADDRESS": {


### PR DESCRIPTION
Update for separate API and console ports in MinIO Docker image.

Fixes #302 .

### Information on docker image
- docker image: <link to image page on docker hub>
- is an official docker image available for this project?: 


### Checklist
- [ ] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [ ] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [ ] `"website"` object links to project's main website
