### PR TITLE
Adds Piwigo - piwigo.org

### DIFF
--- a/piwigo.json
+++ b/piwigo.json
@@ -37,7 +37,7 @@
                 }
 			}
 		},
-		"description": "Piwigo is a photo gallery software for the web that comes with powerful features to publish and manage your collection of pictures.",
+		"description": "Piwigo is a photo gallery software for the web that comes with powerful features to publish and manage your collection of pictures. More information can be found <a href='https://hub.docker.com/r/linuxserver/piwigo' target='_blank'>here</a>",
 		"more_info": "",
 		"ui": {
 			"slug": "gui"

--- a/piwigo.json
+++ b/piwigo.json
@@ -5,9 +5,9 @@
 				"image": "lscr.io/linuxserver/piwigo:latest",
 				"launch_order": 1,
 				"ports": {
-					"8080": {
-						"description": "Port for Web interface. Suggested default: 8080.",
-						"host_default": 8080,
+					"9000": {
+						"description": "Port for Web interface. Suggested default: 9000.",
+						"host_default": 9000,
 						"label": "WebUI port",
 						"protocol": "tcp",
 						"ui": true

--- a/piwigo.json
+++ b/piwigo.json
@@ -1,0 +1,50 @@
+{
+	"piwigo": {
+		"containers": {
+			"utorrent": {
+				"image": "lscr.io/linuxserver/piwigo:latest",
+				"launch_order": 1,
+				"ports": {
+					"8080": {
+						"description": "Port for Web interface. Suggested default: 8080.",
+						"host_default": 8080,
+						"label": "WebUI port",
+						"protocol": "tcp",
+						"ui": true
+					}
+				},
+				"volumes": {
+					"/gallery": {
+						"description": "Directory for your media",
+						"label": "Media"
+					},
+					"/config": {
+						"description": "Holds all the settings files and databases.",
+						"label": "Configurations"
+					}
+				},
+				"environment": {
+                    "PUID": {
+		        		"description": "Enter a valid PUID to run pwigo as. It must have full permissions to all Shares mapped in the previous step.",
+                        "label": "PUID.",
+                        "index": 1
+		    		},
+                    "GUID": {
+                        "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID",
+                        "index": 2
+                    }
+                }
+			}
+		},
+		"description": "Piwigo is a photo gallery software for the web that comes with powerful features to publish and manage your collection of pictures.",
+		"more_info": "",
+		"ui": {
+			"slug": "gui"
+		},
+		"volume_add_support": true,
+		"website": "https://piwigo.org",
+		"version": "2.1"
+	}
+}
+

--- a/piwigo.json
+++ b/piwigo.json
@@ -1,7 +1,7 @@
 {
 	"piwigo": {
 		"containers": {
-			"utorrent": {
+			"piwigo": {
 				"image": "lscr.io/linuxserver/piwigo:latest",
 				"launch_order": 1,
 				"ports": {

--- a/piwigo.json
+++ b/piwigo.json
@@ -25,7 +25,7 @@
 				},
 				"environment": {
                     "PUID": {
-		        		"description": "Enter a valid PUID to run pwigo as. It must have full permissions to all Shares mapped in the previous step.",
+		        		"description": "Enter a valid PUID to run piwigo as. It must have full permissions to all Shares mapped in the previous step.",
                         "label": "PUID.",
                         "index": 1
 		    		},

--- a/root.json
+++ b/root.json
@@ -55,6 +55,7 @@
     "PocketMine": "pocketmine.json",
     "PostgreSQL 9.5": "postgres-9.5.json",
     "PostgreSQL 10.6": "postgres-10.6.json",
+    "Piwigo": "piwigo.json",
     "Radarr": "radarr.json",
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",


### PR DESCRIPTION
### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Pwigo
- website: https://piwigo.org/

- description: Piwigo is open source photo management software.


### Information on docker image
- docker image: https://github.com/linuxserver/docker-piwigo
- is an official docker image available for this project?: yes


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website


### Working using docker run:

I do not know how to incorporate a timezone selector using the json config. But this can be changed later.

```
docker run -d \
  --name=piwigo \
  -e PUID=1000 \
  -e PGID=1000 \
  -e TZ=Europe/London \
  -p 9000:80 \
  -v /config \
  -v /gallery \
  --restart unless-stopped \
  lscr.io/linuxserver/piwigo:latest
```

<img width="1399" alt="image" src="https://user-images.githubusercontent.com/29296982/172052313-b02b309c-48ed-4ffb-83c8-10d131c41aec.png">
