### PR TITLE
Add qBittorrent Rockon based on PR #291

### DIFF
--- a/qbittorrent_lsio.json
+++ b/qbittorrent_lsio.json
@@ -2,8 +2,7 @@
 	"qBittorrent": {
 		"website": "http://www.qBittorrent.org/",
 		"version": "1.1",
-		"description": "qBittorrent client with a WebUI.<p>Note: Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.<p>The initial WebUI user is <code>admin</code> and initial password is <code>adminadmin</code>. This can then be adjusted in the Settings Menu later.</p><p>For a more detailed description, check here <a href='https://docs.linuxserver.io/images/docker-qbittorrent#webui_port-variable' target='_blank'>WebUI Port and CSRF</a>.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/qbittorrent' target='_blank'>https://hub.docker.com/r/linuxserver/qbittorrent</a>, available for amd64 and arm64 architecture.",
-
+		"description": "qBittorrent client with a WebUI.<p>Note: Ensure that the WebUI Port is set to 5345 to prevent issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented (see <a href='https://docs.linuxserver.io/images/docker-qbittorrent#webui_port-variable' target='_blank'>WebUI Port and CSRF</a> for a more detailed description).</p><p>The initial WebUI user is <code>admin</code> and initial password is <code>adminadmin</code>. This can be adjusted in the Settings Menu after first login.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/qbittorrent' target='_blank'>https://hub.docker.com/r/linuxserver/qbittorrent</a>, available for amd64 and arm64 architecture.",
 		"ui": {
 			"slug": ""
 		},
@@ -12,6 +11,12 @@
 			"qBittorrent": {
 				"image": "linuxserver/qbittorrent",
 				"launch_order": 1,
+				"opts": [
+					[
+						"-e",
+						"WEBUI_PORT=5345"
+					]
+				],
 				"volumes": {
 					"/config": {
 						"description": "Configuration for qBittorrent. Ensure the write permissions correspond to the UID/GID entered later for this Rockon.",
@@ -23,9 +28,9 @@
 					}
 				},
 				"ports": {
-					"8080": {
-						"description": "qBittorrent WebUI port. Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.",
-						"host_default": 8080,
+					"5345": {
+						"description": "qBittorrent WebUI port. The WebUI port has to be set to 5345 to prevent issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.",
+						"host_default": 5345,
 						"label": "External WebUI port",
 						"protocol": "tcp",
 						"ui": true
@@ -37,20 +42,15 @@
 					}
 				},
 				"environment": {
-					"WEBUI_PORT": {
-						"description": "Explicitly enter the same port number maintained above for the WebUI port (e.g., 8080 is usually the suggested default for the WebUI port if it is not used in any other Rockon). See the description of WebUI setting for more details.",
-						"label": "WEBUI_PORT",
-						"index": 1
-					},
 					"PUID": {
 						"description": "Enter a valid UID of an existing user with permissions to the download and configuration shares used for qBittorrent.",
 						"label": "UID",
-						"index": 2
+						"index": 1
 					},
 					"PGID": {
 						"description": "Enter a valid GID of an existing user with permissions to the download and configuration shares used for qBittorrent.",
 						"label": "GID",
-						"index": 3
+						"index": 2
 					}
 				}
 			}

--- a/qbittorrent_lsio.json
+++ b/qbittorrent_lsio.json
@@ -1,0 +1,58 @@
+{
+	"qBittorrent": {
+		"website": "http://www.qBittorrent.org/",
+		"version": "1.1",
+		"description": "qBittorrent client with a WebUI.<p>Note: Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.<p>The initial WebUI user is <code>admin</code> and initial password is <code>adminadmin</code>. This can then be adjusted in the Settings Menu later.</p><p>For a more detailed description, check here <a href='WebUI Port and CSRF' target='_blank'>https://docs.linuxserver.io/images/docker-qbittorrent#webui_port-variable</a>.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/qbittorrent' target='_blank'>https://hub.docker.com/r/linuxserver/qbittorrent</a>, available for amd64 and arm64 architecture.",
+		"ui": {
+			"slug": ""
+		},
+		"volume_add_support": true,
+		"containers": {
+			"qBittorrent": {
+				"image": "linuxserver/qbittorrent",
+				"launch_order": 1,
+				"volumes": {
+					"/config": {
+						"description": "Configuration for qBittorrent. Ensure the write permissions correspond to the UID/GID entered later for this Rockon.",
+						"label": "Configuration for qBittorrent"
+					},
+					"/downloads": {
+						"description": "Primary share used for downloads. You can add more after the initial install of this Rockon. Ensure the write permissions correspond to the UID/GID entered later for this Rockon.",
+						"label": "Data storage"
+					}
+				},
+				"ports": {
+					"8080": {
+						"description": "qBittorrent WebUI port. Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.",
+						"host_default": 8080,
+						"label": "External WebUI port",
+						"protocol": "tcp",
+						"ui": true
+					},
+					"6881": {
+						"description": "qBittorrent Torrent port",
+						"host_default": 6881,
+						"label": "Torrent Port"
+					}
+				},
+				"environment": {
+					"WEBUI_PORT": {
+						"description": "Explicitly enter the same port number maintained above for the WebUI port (e.g., 8080 is usually the suggested default for the WebUI port if it is not used in any other Rockon). See the description of WebUI setting for more details.",
+						"label": "WEBUI_PORT",
+						"index": 1
+					},
+					"PUID": {
+						"description": "Enter a valid UID of an existing user with permissions to the download and configuration shares used for qBittorrent.",
+						"label": "UID",
+						"index": 2
+					},
+					"PGID": {
+						"description": "Enter a valid GID of an existing user with permissions to the download and configuration shares used for qBittorrent.",
+						"label": "GID",
+						"index": 3
+					}
+				}
+			}
+		}
+	}
+}

--- a/qbittorrent_lsio.json
+++ b/qbittorrent_lsio.json
@@ -2,7 +2,8 @@
 	"qBittorrent": {
 		"website": "http://www.qBittorrent.org/",
 		"version": "1.1",
-		"description": "qBittorrent client with a WebUI.<p>Note: Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.<p>The initial WebUI user is <code>admin</code> and initial password is <code>adminadmin</code>. This can then be adjusted in the Settings Menu later.</p><p>For a more detailed description, check here <a href='WebUI Port and CSRF' target='_blank'>https://docs.linuxserver.io/images/docker-qbittorrent#webui_port-variable</a>.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/qbittorrent' target='_blank'>https://hub.docker.com/r/linuxserver/qbittorrent</a>, available for amd64 and arm64 architecture.",
+		"description": "qBittorrent client with a WebUI.<p>Note: Ensure that the WebUI Port is the same as the WEBUI_PORT to avoid issues with the Cross-Site Request Forgery (CSRF) protection that qBittorrent has implemented.<p>The initial WebUI user is <code>admin</code> and initial password is <code>adminadmin</code>. This can then be adjusted in the Settings Menu later.</p><p>For a more detailed description, check here <a href='https://docs.linuxserver.io/images/docker-qbittorrent#webui_port-variable' target='_blank'>WebUI Port and CSRF</a>.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/qbittorrent' target='_blank'>https://hub.docker.com/r/linuxserver/qbittorrent</a>, available for amd64 and arm64 architecture.",
+
 		"ui": {
 			"slug": ""
 		},

--- a/root.json
+++ b/root.json
@@ -54,6 +54,7 @@
     "PocketMine": "pocketmine.json",
     "PostgreSQL 9.5": "postgres-9.5.json",
     "PostgreSQL 10.6": "postgres-10.6.json",
+    "qBittorrent": "qbittorrent_lsio.json",
     "Radarr": "radarr.json",
     "Resilio Sync": "resilioSync.json",
     "Rocket.Chat": "rocketchat.json",


### PR DESCRIPTION
Since there has not been any updates on Pull Request #291, wanted to submit a PR that includes requested changes and some additional (cosmetic) updates to the originally proposed Rockon. It is based on the same image as the original PR. Additionally, I have exposed the WEBUI_PORT environment variable to account for the need to have both container port and Rockon port to match (with appropriate description and links).

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: qBittorrent
- website: https://qBittorrent.org
- description: this Rockon runs the qBittorrent client with a WebUI. Since the uTorrent client will be deprecated and qbittorrent offers additional functional like sequential downloads compared to the Transmission client, this should be a good "fill-in" between the two.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/qbittorrent
- is an official docker image available for this project?: No
- Linuxserver.io provides the best multi-architecture docker image for this application.

### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
