### PR TITLE
#307 Create airsonic-advanced.json

### DIFF
--- a/airsonic-advanced.json
+++ b/airsonic-advanced.json
@@ -1,0 +1,67 @@
+{
+    "Airsonic Advanced": {
+        "containers": {
+            "airsonic-advanced": {
+                "image": "linuxserver/airsonic-advanced",
+                "launch_order": 1,
+                "ports": {
+                    "4040": {
+                        "description": "Webserver Port. Required default: 4040.",
+                        "host_default": 4040,
+                        "label": "Webserver port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for Airsonic configuration. Eg: create a Share called airsonic-config for this purpose alone.",
+                        "label": "Config Storage",
+                        "min_size": 1073741824
+                    },
+                    "/music": {
+                        "description": "Select the Share containing your Media",
+                        "label": "Music Storage",
+                        "min_size": 1073741824
+                    },
+                    "/playlists": {
+                        "description": "Choose a Share for Airsonic playlists. Eg: create a Share called airsonic-playlists for this purpose alone.",
+                        "label": "Playlist Storage",
+                        "min_size": 1073741824
+                    },
+                    "/podcasts": {
+                        "description": "Select the Share to store podcasts",
+                        "label": "Podcast Storage",
+                        "min_size": 1073741824
+                    }
+                },
+                "environment": {
+                    "MAX_MEM": {
+                        "description": "This environment variable is used to set the maximum Java heap size in megabytes - 150 is a good default",
+                        "label": "MAX_MEM",
+                        "index": 1
+                    },
+                    "PUID": {
+                        "description": "Enter a valid UID of an existing user with permission to media shares to run Airsonic as (default: 1001).",
+                        "label": "UID",
+                        "index": 2,
+                        "default": 1001
+                    },
+                    "PGID": {
+                        "description": "Enter a valid GID of an existing user with permission to media shares to run Airsonic as (default: 100.",
+                        "label": "GID",
+                        "index": 3,
+                        "default": 100
+                    }
+                }
+            }
+        },
+        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for amd64 and arm64 architectures only.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "website": "https://airsonic.github.io/",
+        "version": "2.1"
+    }
+	}

--- a/airsonic-advanced.json
+++ b/airsonic-advanced.json
@@ -56,7 +56,7 @@
                 }
             }
         },
-        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for x86-64 and arm64 architectures.</p>",
+        "description": "Airsonic music server. <p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for x86-64 and arm64 architectures.</p>",
         "ui": {
             "slug": ""
         },

--- a/airsonic-advanced.json
+++ b/airsonic-advanced.json
@@ -56,7 +56,7 @@
                 }
             }
         },
-        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for amd64 and arm64 architectures only.</p>",
+        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for x86-64 and arm64 architectures only.</p>",
         "ui": {
             "slug": ""
         },

--- a/airsonic-advanced.json
+++ b/airsonic-advanced.json
@@ -56,7 +56,7 @@
                 }
             }
         },
-        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for x86-64 and arm64 architectures only.</p>",
+        "description": "Airsonic music server. <p>Based on a linuxserver docker image: <a href='https://hub.docker.com/r/linuxserver/airsonic-advanced' target='_blank'>https://hub.docker.com/r/linuxserver/airsonic-advanced</a>, available for x86-64 and arm64 architectures.</p>",
         "ui": {
             "slug": ""
         },

--- a/root.json
+++ b/root.json
@@ -1,4 +1,5 @@
 {
+    "Airsonic Advanced": "airsonic-advanced.json",
     "Bitcoin": "bitcoind.json",
     "Booksonic": "booksonic.json",
     "Collabora Online": "collabora-online.json",


### PR DESCRIPTION
Airsonic Rock-On proposal config for a Subsonic replacement.

> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes #307  .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Rockstor rockon-registry / Airsonic MPD.
- website: https://github.com/linuxserver/docker-airsonic-advanced
- description: <brief description of the project and how it intergrates with Rockstor> Music Playen Daemon to control music library from sefl-hosted server.

Optional parameters to valuate:

      - TZ=Europe/London | Seems to work without, is this required ?
      - CONTEXT_PATH=<URL_BASE> #optional
      - JAVA_OPTS=<options> #optional (for Jukebox feature)
      - devices: /dev/snd:/dev/snd #optional (for Juebox feature)

Jukebox functionality explained:

> If you configure a machine in Jukebox mode, the idea is that instead of the music playing back over the client machine, it plays on the host machine. Think like, you have a machine connected to an entertainment center and you want to use Airsonic as the music player. Add to that, you can use your phone or any web client to control the jukebox. It is a type of airplay. You use mobile devices to control a wired device somewhere in your house.


### Information on docker image
- docker image: <link to image page on docker hub> https://hub.docker.com/r/linuxserver/airsonic
- is an official docker image available for this project?: It is relative, this a forked community image,


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
