### PR TITLE
Tailscale Rock-on incomplete #328

### DIFF
--- a/root.json
+++ b/root.json
@@ -60,6 +60,7 @@
     "SmokePing": "smokeping.json",
     "Sonarr": "sonarr.json",
     "Syncthing": "syncthing.json",
+    "Tailscale": "tailscale.json",
     "Tautulli": "tautulli.json",
     "TeamSpeak3": "teamspeak3.json",
     "Transmission with OpenVPN": "transmission-with-openvpn.json",

--- a/tailscale.json
+++ b/tailscale.json
@@ -1,10 +1,10 @@
 {
     "Tailscale": {
         "containers": {
-            "launch_order": 1,
             "tailscaled": {
                 "image": "tailscale/tailscale",
                 "tag": "stable",
+                "launch_order": 1,
                 "opts": [
                     [
                         "--net=host",
@@ -22,13 +22,28 @@
                         "-v",
                         "/dev/net/tun:/dev/net/tun"
                     ]
-                ]
+                ],
+                "environment": {
+                    "TS_AUTH_KEY": {
+                        "description": "Pre-authorized key generated from Tailscale Settings->Keys",
+                        "label": "Auth key"
+                    }
+                },
+                "ports": {
+                    "8088": {
+                        "description": "Tailscale local configuration WebUI port. Suggested port: 8088",
+                        "host_default": 8088,
+                        "label": "Web-UI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                }
             }
         },
-        "description": "Zero config VPN based on the open source WireGuard protocol. Access your devices and applications from anywhere.<p>Note: this container uses host networking, allowing privileged network access.<p>Based on the official stable docker image: <a href='https://hub.docker.com/r/tailscale/tailscale' target='_blank'>https://hub.docker.com/r/tailscale/tailscale</a>, available for amd64 and arm64 architecture.</p>",
+        "description": "Zero config VPN using WireGuard. Access your devices securely from anywhere.<p>Note: uses host networking with privileged network access.<p><p>Requires the generation of a tailnet <a href='https://tailscale.com/kb/1085/auth-keys/' target='_blank'>Auth Key:</a> via Tailscale <a href='https://login.tailscale.com/admin/settings/keys' target='_blank'>Settings->Keys</a><p>Based on the official stable docker image: <a href='https://hub.docker.com/r/tailscale/tailscale' target='_blank'>https://hub.docker.com/r/tailscale/tailscale</a>, available for amd64 and arm64 architecture.</p>",
         "version": "1.0",
         "website": "https://tailscale.com/",
         "icon": "https://tailscale.com/files/images/og-image.png",
-        "more_info": "Default <a href='https://tailscale.com/kb/1028/key-expiry/' target='_blank'>Key Expiry</a> is 180 days. Temporary extension possible."
+        "more_info": "Default <a href='https://tailscale.com/kb/1028/key-expiry/' target='_blank'>Key Expiry</a> is 180 days. Temporary extension possible.<p> Web interface enable as root <code>docker exec tailscaled tailscale web</code>"
     }
 }

--- a/tailscale.json
+++ b/tailscale.json
@@ -21,12 +21,21 @@
                     [
                         "-v",
                         "/dev/net/tun:/dev/net/tun"
+                    ],
+                    [
+                        "-e",
+                        "TS_WEBUI=true"
+                    ],
+                    [
+                        "-e",
+                        "TS_STATE_DIR=/statedir"
                     ]
                 ],
-                "environment": {
-                    "TS_AUTH_KEY": {
-                        "description": "Pre-authorized key generated from Tailscale Settings->Keys",
-                        "label": "Auth key"
+                "volumes": {
+                    "/statedir": {
+                        "description": "Choose a Share for Tailscale's local configuration. Eg: create a Share called tailscale-config for this purpose alone.",
+                        "label": "Config Storage",
+                        "min_size": 1073741824
                     }
                 },
                 "ports": {
@@ -40,7 +49,7 @@
                 }
             }
         },
-        "description": "Zero config VPN using WireGuard. Access your devices securely from anywhere.<p>Note: uses host networking with privileged network access.<p><p>Requires the generation of a tailnet <a href='https://tailscale.com/kb/1085/auth-keys/' target='_blank'>Auth Key:</a> via Tailscale <a href='https://login.tailscale.com/admin/settings/keys' target='_blank'>Settings->Keys</a><p>Based on the official stable docker image: <a href='https://hub.docker.com/r/tailscale/tailscale' target='_blank'>https://hub.docker.com/r/tailscale/tailscale</a>, available for amd64 and arm64 architecture.</p>",
+        "description": "Zero config VPN using WireGuard. Access your devices securely from anywhere.<p>Note: uses host networking with privileged network access.<p>Based on the official stable docker image: <a href='https://hub.docker.com/r/tailscale/tailscale' target='_blank'>https://hub.docker.com/r/tailscale/tailscale</a>, available for amd64 and arm64 architecture.</p>",
         "version": "1.0",
         "website": "https://tailscale.com/",
         "icon": "https://tailscale.com/files/images/og-image.png",

--- a/tailscale.json
+++ b/tailscale.json
@@ -1,0 +1,34 @@
+{
+    "Tailscale": {
+        "containers": {
+            "launch_order": 1,
+            "tailscaled": {
+                "image": "tailscale/tailscale",
+                "tag": "stable",
+                "opts": [
+                    [
+                        "--net=host",
+                        ""
+                    ],
+                    [
+                        "--privileged",
+                        ""
+                    ],
+                    [
+                        "-v",
+                        "/var/lib:/var/lib"
+                    ],
+                    [
+                        "-v",
+                        "/dev/net/tun:/dev/net/tun"
+                    ]
+                ]
+            }
+        },
+        "description": "Zero config VPN based on the open source WireGuard protocol. Access your devices and applications from anywhere.<p>Note: this container uses host networking, allowing privileged network access.<p>Based on the official stable docker image: <a href='https://hub.docker.com/r/tailscale/tailscale' target='_blank'>https://hub.docker.com/r/tailscale/tailscale</a>, available for amd64 and arm64 architecture.</p>",
+        "version": "1.0",
+        "website": "https://tailscale.com/",
+        "icon": "https://tailscale.com/files/images/og-image.png",
+        "more_info": "Default <a href='https://tailscale.com/kb/1028/key-expiry/' target='_blank'>Key Expiry</a> is 180 days. Temporary extension possible."
+    }
+}


### PR DESCRIPTION
Currently incomplete and awaiting upstream modifications to the official docker run.sh to enable web based initialisation, and re-auth when required.

It is proposed that in-time we focus on adding a Tailscale service 'proper' given this technologies value, and mind share, for future capabilities regarding remote access, an oft requested config/capability. However a Rock-on may serve well in the mean time given our limited developer resources.

- [ ] Add status command guide to info section: "docker exec tailscaled tailscale --socket=/tmp/tailscaled.sock status" as this would be usefull for diagnostic purposes.
