### PR TITLE
#332 Add project Omada Controller as Rock-on

### DIFF
--- a/omada-controller.json
+++ b/omada-controller.json
@@ -1,0 +1,172 @@
+{
+    "Omada Controller": {
+        "containers": {
+            "omada-controller": {
+                "image": "mbentley/omada-controller",
+                "launch_order": 1,
+                "ports": {
+                    "8088": {
+                        "description": "Management and User web portal HTTP port. Suggested default: 8088.",
+                        "host_default": 8088,
+                        "label": "Management + User HTTP",
+                        "protocol": "tcp"
+                    },
+                    "8043": {
+                        "description": "Management web portal HTTPS port. Suggested default: 8043.",
+                        "host_default": 8043,
+                        "label": "Management HTTPS",
+                        "protocol": "tcp",
+                        "ui": true
+                    },
+                    "8843": {
+                        "description": "User web portal HTTPS port. Suggested default: 8843.",
+                        "host_default": 8843,
+                        "label": "User HTTPS",
+                        "protocol": "tcp"
+                    },                   
+                    "27001": {
+                        "description": "Omada Controller can be discovered by the Omada app through this port. Suggested default: 27001.",
+                        "host_default": 27001,
+                        "label": "App discovery",
+                        "protocol": "udp"
+                    },
+                    "29810": {
+                        "description": "Omada Controller and Omada Discovery Utility discover Omada devices through this port. Suggested default: 29810.",
+                        "host_default": 29810,
+                        "label": "Device discovery",
+                        "protocol": "udp"
+                    },
+                    "29811": {
+                        "description": "Omada Controller and Omada Discovery Utility manage Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29811.",
+                        "host_default": 29811,
+                        "label": "Device managing (v4)",
+                        "protocol": "tcp"                    
+                    },
+                    "29812": {
+                        "description": "Omada Controller and Omada Discovery Utility manage/adopt Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29812.",
+                        "host_default": 29812,
+                        "label": "Device adoption (v4)",
+                        "protocol": "tcp"                    
+                    },
+                    "29813": {
+                        "description": "When upgrading the firmware for the Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29813.",
+                        "host_default": 29813,
+                        "label": "Firmware upgrade (v4)",
+                        "protocol": "tcp"                    
+                    },
+                    "29814": {
+                        "description": "Omada Controller and Omada Discovery Utility manage Omada devices running firmware fully adapted to Omada Controller v5*. Suggested default: 29814.",
+                        "host_default": 29814,
+                        "label": "Device managing (v5)",
+                        "protocol": "tcp"                    
+                    }  
+                },
+                "volumes": {
+                    "/opt/tplink/EAPController/data": {
+                        "description": "Choose a DATA and CONFIG Share for Omada Controller files. Eg: create a Share called omada-controller-data for this purpose alone.",
+                        "label": "Controller DATA + CONFIG Storage"
+                    },
+                    "/opt/tplink/EAPController/logs": {
+                        "description": "Choose a LOGS Share for Omada Controller files. Eg: create a Share called omada-controller-logs for this purpose alone.",
+                        "label": "Controller LOGS Storage"
+                    }  
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter the valid UID 'omada' process user ID. It must have full permissions to all Shares mapped in the previous step. Suggested default: 508.",
+                        "label": "UID",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter the valid GID 'omada' process group ID to use along with the same UID. It (or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID",
+                        "index": 2
+                    },
+                    "MANAGE_HTTP_PORT": {
+                        "description": "Management and User web portal HTTP port. Suggested default: 8088.",
+                        "label": "Management HTTP port",
+                        "index": 3
+                    },
+                    "MANAGE_HTTPS_PORT": {
+                        "description": "Management web portal HTTPS port. Suggested default: 8043.",
+                        "label": "Management HTTPS port",
+                        "index": 4
+                    },                                    
+                    "PORTAL_HTTP_PORT": {
+                        "description": "User web portal HTTP port. Suggested default: 8088.",
+                        "label": "User HTTP port",
+                        "index": 5
+                    },
+                    "PORTAL_HTTPS_PORT": {
+                        "description": "User web portal HTTPS port. Suggested default: 8843.",
+                        "label": "User HTTPS port",
+                        "index": 6
+                    },
+                    "PORT_ADOPT_V1": {
+                        "description": "Omada Controller and Omada Discovery Utility manage/adopt Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29812.",
+                        "label": "Device managing (v4)",
+                        "index": 7
+                    },
+                    "PORT_APP_DISCOVERY": {
+                        "description": "Omada Controller can be discovered by the Omada app through this port. Suggested default: 27001.",
+                        "label": "App discovery",
+                        "index": 8
+                    },
+                    "PORT_DISCOVERY": {
+                        "description": "Omada Controller and Omada Discovery Utility discover Omada devices through this port. Suggested default: 29810.",
+                        "label": "Device discovery",
+                        "index": 9
+                    },
+                    "PORT_MANAGER_V1": {
+                        "description": "Omada Controller and Omada Discovery Utility manage Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29811.",
+                        "label": "Device managing (v4)",
+                        "index": 10
+                    },
+                    "PORT_MANAGER_V2": {
+                        "description": "Omada Controller and Omada Discovery Utility manage Omada devices running firmware fully adapted to Omada Controller v5*. Suggested default: 29814.",
+                        "label": "Device managing (v5)",
+                        "index": 11
+                    },
+                    "PORT_UPGRADE_V1": {
+                        "description": "When upgrading the firmware for the Omada devices running firmware fully adapted to Omada Controller v4*. Suggested default: 29813.",
+                        "label": "Firmware upgrade (v4)",
+                        "index": 12
+                    },
+                    "SHOW_SERVER_LOGS": {
+                        "description": "Outputs Omada Controller logs to STDOUT at runtime. Suggested default: true.",
+                        "label": "Show server logs",
+                        "index": 13
+                    },
+                    "SHOW_MONGODB_LOGS": {
+                        "description": "Outputs MongoDB logs to STDOUT at runtime. Suggested default: false.",
+                        "label": "Show MongoDB logs",
+                        "index": 14
+                    },
+                    "SSL_CERT_NAME": {
+                        "description": "Name of the public certificate chain mounted to /cert. Suggested default: tls.crt.",
+                        "label": "SSL certificate name",
+                        "index": 15
+                    },
+                    "SSL_KEY_NAME": {
+                        "description": "Name of the private certificate mounted to /cert. Suggested default: tls.key.",
+                        "label": "SSL key name",
+                        "index": 16
+                    },
+                    "TLS_1_11_ENABLED": {
+                        "description": "Re-enables TLS 1.0 and 1.1 if set to true. Suggested default: false.",
+                        "label": "Enable unsecure TLS versions",
+                        "index": 17
+                    }                    
+                }
+            }
+        },
+        "description": "TP-Link Omada Controller. <p>Based on a custom docker image: <a href='https://hub.docker.com/r/mbentley/omada-controller' target='_blank'>https://hub.docker.com/r/mbentley/omada-controller</a>, available for amd64 and arm64 architecture.</p>",
+        "ui": {
+            "https": true,
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "website": "https://www.tp-link.com/us/support/download/omada-software-controller/",
+        "version": "1.0"
+    }
+}

--- a/omada-controller.json
+++ b/omada-controller.json
@@ -78,7 +78,7 @@
                         "index": 1
                     },
                     "PGID": {
-                        "description": "Enter the valid GID 'omada' process group ID to use along with the same UID. It (or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "description": "Enter an existing Group ID (GID) to run this Rock-on. This group (or prior UID) must already have full permissions to Shares used by this Rock-on.",
                         "label": "GID",
                         "index": 2
                     },

--- a/omada-controller.json
+++ b/omada-controller.json
@@ -73,7 +73,7 @@
                 },
                 "environment": {
                     "PUID": {
-                        "description": "Enter the valid UID 'omada' process user ID. It must have full permissions to all Shares mapped in the previous step. Suggested default: 508.",
+                        "description": "Enter an existing User ID (UID) to run this Rock-on. They must already have full permissions to Shares used by this Rock-on.",
                         "label": "UID",
                         "index": 1
                     },

--- a/root.json
+++ b/root.json
@@ -44,6 +44,7 @@
     "Node-Red": "nodered.json",
     "NZBGet": "nzbget.json",
     "NZBHydra2": "NZBHydra2.json",
+    "Omada Controller": "omada-controller.json",    
     "Ombi": "ombi.json",
     "OpenVPN": "openvpn.json",
     "OwnCloud": "owncloud.json",


### PR DESCRIPTION
Fixes #332 .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Omada Software Controller
- website: https://www.tp-link.com/us/support/download/omada-software-controller/
- description: This docker image contains the software controller for the TP-Link's Omada networking devices. This software controller is needed when you want to manage all your Omada devices from a single WebUI, and when you want special features which depend on it. 

### Information on docker image
- docker image: https://hub.docker.com/r/mbentley/omada-controller
- is an official docker image available for this project?: No.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
