### PR TITLE
updates jellyfin rockon configuration

### DIFF
--- a/jellyfin-linuxserver.json
+++ b/jellyfin-linuxserver.json
@@ -2,7 +2,7 @@
     "Jellyfin": {
         "description": "Jellyfin media server: The Free Software Media System<p>Jellyfin is the volunteer-built media solution that puts you in control of your media.<br>Stream to any device from your own server, with no strings attached.<br>Your media, your server, your way.</p><p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/jellyfin' target='_blank'>https://hub.docker.com/r/linuxserver/jellyfin</a>, available for amd64 and arm64 architecture.</p>",
         "more_info": "<h4>Adding media to Jellyfin.</h4><p>You can add Shares (with media) to Jellyfin from the settings wizard of this Rock-on. Then, from Jellyfin WebUI, you can update and re-index your library.</p><p> Visit https://hub.docker.com/r/linuxserver/jellyfin for description of each option.</p><p>NOTE: Due to some current <a href='https://github.com/rockstor/rockstor-core/issues/2209' target='_blank'>limitations in Rock-On networking</a>, this Rock-On cannot be installed at the same time as Emby, as they use the same port number, which must be 8096.</p>",
-        "version": "0.0.2",
+        "version": "0.0.3",
         "website": "https://jellyfin.org",
         "icon": "https://jellyfin.org/docs/images/header-icon.svg",
         "ui": {
@@ -34,10 +34,24 @@
                         "ui": true
                     },
                     "8920": {
-                        "description": "Jellyfin HTTPS port. Suggested default: 8920",
+                        "description": "Optional - Jellyfin WebUI HTTPS port. Suggested default: 8920",
                         "host_default": 8920,
                         "label": "HTTPS port",
                         "protocol": "tcp",
+                        "ui": false
+                    },
+                    "7359": {
+                        "description": "Optional - Allows clients to discover Jellyfin on the local network. Suggested default: 7359",
+                        "host_default": 7359,
+                        "label": "Client Discovery port",
+                        "protocol": "udp",
+                        "ui": false
+                    },
+                    "1900": {
+                        "description": "Optional - Service discovery used by DNLA and clients. Suggested default: 1900",
+                        "host_default": 1900,
+                        "label": "Service Discovery port",
+                        "protocol": "udp",
                         "ui": false
                     }
                 },


### PR DESCRIPTION
the jellyfin docker image offers two additional ports which enable Service and Client Discovery (DLNA). 
these are now configurable via the RockOn UI interface

> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes #344 .


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [N/A] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
