### PR TITLE
Add Rockon for SpeedTest  tool

### DIFF
--- a/OpenSpeedTest.json
+++ b/OpenSpeedTest.json
@@ -1,0 +1,25 @@
+{
+  "SpeedTest by OpenSpeedTest": {
+    "containers": {
+      "speedtest": {
+        "image": "openspeedtest/latest",
+		"launch_order": 1,
+		"ports": {
+			"3000": {
+				"description": "SpeedTest http WebUI port. Suggested Default: 3000",
+				"host_default": 3000,
+				"label": "http WebUI port",
+				"ui": true
+			}
+		}
+      }
+    },
+    "description": "<p>SpeedTest by OpenSpeedTest™ is a free and open-source HTML5 network performance estimation tool. Written in vanilla Javascript it only uses built-in Web APIs like XMLHttpRequest (XHR), HTML, CSS, JS, &amp; SVG. No third-party frameworks or libraries are required.<p>Based on the official docker image: <a href='https://hub.docker.com/r/openspeedtest/latest' target='_blank'> https://hub.docker.com/r/openspeedtest/latest/</a>, available for amd64 and arm64 architecture.</p>",
+    "ui": {
+      "https": false,
+      "slug": ""
+    },
+    "website": "https://openspeedtest.com/",
+    "version": "1.0"
+  }
+}

--- a/root.json
+++ b/root.json
@@ -62,6 +62,7 @@
     "SickChill": "sickchill.json",
     "SmokePing": "smokeping.json",
     "Sonarr": "sonarr.json",
+    "SpeedTest by OpenSpeedTest": "OpenSpeedTest.json",
     "Syncthing": "syncthing.json",
     "Tautulli": "tautulli.json",
     "TeamSpeak3": "teamspeak3.json",


### PR DESCRIPTION
Fixes #354 .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: SpeedTest by OpenSpeedTest
- website: https://openspeedtest.com/
- description: SpeedTest by OpenSpeedTest™ is a Free and Open-Source HTML5 Network Performance Estimation Tool. Setup for http connection only.

### Information on docker image
- docker image: [<link to image page on docker hub>](https://hub.docker.com/r/openspeedtest/latest)
- is an official docker image available for this project?: yes, above is the offical one.


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
