### PR TITLE
New Filebrowser Rockon

### DIFF
--- a/filebrowser.json
+++ b/filebrowser.json
@@ -1,0 +1,53 @@
+{
+  "Filebrowser": {
+    "containers": {
+      "filebrowser": {
+        "image": "filebrowser/filebrowser",
+        "tag": "s6",
+        "launch_order": 1,
+        "ports": {
+          "80": {
+            "description": "filebrowser Webui port, Default: 8090",
+            "host_default": 8090,
+            "label": "WebUI port",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "volumes": {
+          "/srv": {
+            "description": "Choose a Share where the files are located that filemanager should have access to. E.g.: select the share where all your files are located",
+            "label": "Data Storage"
+          },
+          "/config": {
+            "description": "Choose a Share for the filebrowser configuration. E.g.: create a share called fb-config for this purpose alone.",
+            "label": "Config Storage"
+          },
+          "/database": {
+            "description": "Choose a Share for filebrowser's database file. E.g.: create a Share called fb-db for this purpose alone. Important: For the first install ensure that the share contains an empty file named `filebrowser.db` to avoid errors during the initial installation.",
+            "label": "Database Location"
+          }
+        },
+        "environment": {
+          "PUID": {
+            "description": "Enter a valid UID to run filebrowser as. It must have full permissions to all Shares mapped in the previous step.",
+            "label": "UID to run filebrowser as.",
+            "index": 1
+          },
+          "PGID": {
+            "description": "Enter a valid GID to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+            "label": "GID to run filebrowser as.",
+            "index": 2
+          }
+        }
+      }
+    },
+    "description": "Filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory. It can be used as a standalone app.<p>Based on the standard docker image: <a href='https://hub.docker.com/r/filebrowser/filebrowser' target='_blank'>https://hub.docker.com/r/filebrowser/filebrowser</a>, available for amd64 and arm64 architecture.</p><p>For more installation details visit <a href='https://filebrowser.org/installation' target='_blank'>https://filebrowser.org/installation</a></p>",
+    "ui": {
+      "slug": ""
+    },
+    "volume_add_support": false,
+    "website": "https://filebrowser.org/",
+    "version": "1.0"
+  }
+}

--- a/root.json
+++ b/root.json
@@ -12,6 +12,7 @@
     "ecoDMS 18.09": "ecodms18-09.json",
     "Emby server": "embyserver.json",
     "FileBot Node": "filebot-node.json",
+    "Filebrowser": "filebrowser.json",
     "Folding@home Linuxserver.io": "foldingathome-linuxserver.json",
     "FreshRSS": "FreshRSS.json",
     "Ghost": "ghost.json",


### PR DESCRIPTION
Fixes #364  .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Filebrowser
- website: https://filebrowser.org/
- description: filebrowser provides a file managing interface within a specified directory and it can be used to upload, delete, preview, rename and edit your files. It allows the creation of multiple users and each user can have its own directory. It can be used as a standalone app.

### Information on docker image
- docker image: [<link to image page on docker hub>](https://hub.docker.com/r/filebrowser/filebrowser)
- is an official docker image available for this project?: Official image, using the version with linuxservers S6 as base layer


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
