### PR TITLE
Create F2Auth Rockon

### DIFF
--- a/2FAuth.json
+++ b/2FAuth.json
@@ -1,0 +1,39 @@
+{
+    "2FAuth": {
+        "containers": {
+            "2fauth": {
+                "image": "2fauth/2fauth",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "-e",
+                        "AUTHENTICATION_GUARD=web-guard"
+                    ]
+                ],
+                "ports": {
+                    "8000": {
+                        "description": "2FAuth WebUI port. Suggested default: 18000",
+                        "host_default": 18000,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/2fauth": {
+                        "description": "Choose a Share to store 2FAuth related files. Ensure that the share provides Read/Write for UID/GID 1000/1000. E.g.: create a Share called 2FAuth-config for this purpose alone.",
+                        "label": "Config Storage"
+                    }
+                }
+            }
+        },
+        "description": "2FAuth is a web based self-hosted alternative to One Time Passcode (OTP) generators like Google Authenticator, designed for both mobile and desktop. Note, that the container runs with UID/GID 1000/1000, so the configured share must provide the corresponding access.<p>Based on official docker image: <a href='https://hub.docker.com/r/2fauth/2fauth' target='_blank'>https://hub.docker.com/r/2fauth/2fauth</a>, available for amd64 architecture only.</p>",
+        "icon": "https://github.com/Bubka/2FAuth/blob/master/public/favicon.png",
+        "more_info": "The full documentation for this rock-on can be found at <a href='https://docs.2fauth.app/' target='_blank'>https://docs.2fauth.app/</a>.",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://docs.2fauth.app/",
+        "version": "1.0"
+    }
+}

--- a/2FAuth.json
+++ b/2FAuth.json
@@ -24,10 +24,22 @@
                         "description": "Choose a Share to store 2FAuth related files. Ensure that the share provides Read/Write for UID/GID 1000/1000. E.g.: create a Share called 2FAuth-config for this purpose alone.",
                         "label": "Config Storage"
                     }
+                },
+                "environment": {
+                    "APP_URL": {
+                        "description": "Enter http://<myservername>:<UI Port>, using the 2FAuth WebUI port defined before.",
+                        "label": "APP_URL",
+                        "index": 1
+                    },
+                    "ASSET_URL": {
+                        "description": "Enter http://<myservername>:<UI Port>, using the 2FAuth WebUI port defined before.",
+                        "label": "ASSET_URL",
+                        "index": 2
+                    }
                 }
             }
         },
-        "description": "2FAuth is a web based self-hosted alternative to One Time Passcode (OTP) generators like Google Authenticator, designed for both mobile and desktop. Note, that the container runs with UID/GID 1000/1000, so the configured share must provide the corresponding access.<p>Based on official docker image: <a href='https://hub.docker.com/r/2fauth/2fauth' target='_blank'>https://hub.docker.com/r/2fauth/2fauth</a>, available for amd64 architecture only.</p>",
+        "description": "2FAuth is a web based self-hosted alternative to One Time Passcode (OTP) generators like Google Authenticator, designed for both mobile and desktop. Note, that the container runs with UID/GID 1000/1000, so the configured share must provide the corresponding access.<p>Based on official docker image: <a href='https://hub.docker.com/r/2fauth/2fauth' target='_blank'>https://hub.docker.com/r/2fauth/2fauth</a>, available for amd64 and arm64 architecture</p>",
         "icon": "https://github.com/Bubka/2FAuth/blob/master/public/favicon.png",
         "more_info": "The full documentation for this rock-on can be found at <a href='https://docs.2fauth.app/' target='_blank'>https://docs.2fauth.app/</a>.",
         "ui": {

--- a/root.json
+++ b/root.json
@@ -1,5 +1,5 @@
 {
-    "F2Auth": "F2Auth.json",
+    "2FAuth": "2FAuth.json",
     "Airsonic Advanced": "airsonic-advanced.json",
     "Booksonic": "booksonic.json",
     "Collabora Online": "collabora-online.json",

--- a/root.json
+++ b/root.json
@@ -1,4 +1,5 @@
 {
+    "F2Auth": "F2Auth.json",
     "Airsonic Advanced": "airsonic-advanced.json",
     "Booksonic": "booksonic.json",
     "Collabora Online": "collabora-online.json",


### PR DESCRIPTION
Fixes #360  .

Note, since this is a draft PR, the root.json has not been updated yet for this PR, in case the direction (aka different docker target) is more viable.

Currently, the installation completes, the container seems to be the running its processes, however the UI screen is blank. Needs further investigation whether it's related to container itself or the Rockon json/other. If anybody has experience with this container/application, please consider helping analyze the issue.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: 2FAuth (Desktop authenticator)
- website: https://docs.2fauth.app/
- description: 2FAuth is a web based self-hosted alternative to One Time Passcode (OTP) generators like Google Authenticator, designed for both mobile and desktop.

### Information on docker image
- docker image: https://hub.docker.com/r/2fauth/2fauth
- is an official docker image available for this project?: yes, available for amd64 and arm64


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
