### PR TITLE
Add `DOCKER_MODS` support to Jellyfin rockon

### DIFF
--- a/jellyfin-linuxserver.json
+++ b/jellyfin-linuxserver.json
@@ -65,7 +65,7 @@
                         "default":1000
                     },
                     "DOCKER_MODS": {
-                        "description": "(Optional) Docker mods for Jellyfin to support hardware accelleration in specific cases. For OpenCL based DV, HDR10 and HLG tone-mapping use \"linuxserver/mods:jellyfin-opencl-intel\". See https://github.com/linuxserver/docker-jellyfin?tab=readme-ov-file#docker-mods for more details.",
+                        "description": "(Optional) Docker mods for Jellyfin to support hardware accelleration in specific cases. For OpenCL based DV, HDR10 and HLG tone-mapping use \"linuxserver/mods:jellyfin-opencl-intel\". See https://github.com/linuxserver/docker-jellyfin?tab=readme-ov-file#docker-mods for more details. For default enter: \"\"",
                         "label": "DOCKER_MODS",
                         "index": 3,
                         "default": ""

--- a/jellyfin-linuxserver.json
+++ b/jellyfin-linuxserver.json
@@ -63,6 +63,12 @@
                         "label": "GID",
                         "index": 2,
                         "default":1000
+                    },
+                    "DOCKER_MODS": {
+                        "description": "(Optional) Docker mods for Jellyfin to support hardware accelleration in specific cases. For OpenCL based DV, HDR10 and HLG tone-mapping use \"linuxserver/mods:jellyfin-opencl-intel\". See https://github.com/linuxserver/docker-jellyfin?tab=readme-ov-file#docker-mods for more details.",
+                        "label": "DOCKER_MODS",
+                        "index": 3,
+                        "default": ""
                     }
                 }
             }


### PR DESCRIPTION
Simplifies configuration to enable hardware support in Jellyfin.

Empty string as a default seems to work reasonably, and adding hardware support works. 

> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))

Fixes #376.

### General information on project
This pull request proposes to add a new rock-on for the following project: N/A

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/jellyfin
- is an official docker image available for this project?: Yes


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only) (N/A)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
