### PR TITLE
Replace LMS docker image with new community version (#381)

### DIFF
--- a/lms_latest.json
+++ b/lms_latest.json
@@ -1,54 +1,70 @@
 {
-	"Logitech Media Server - Latest Stable": {
-		"description": "Logitech Media Server (aka Squeezebox, slimserver, etc.). Latest stable version. For future updates see more information icon after first installation.<p>Based on a custom docker image: <a href='https://hub.docker.com/r/doliana/logitech-media-server' target='_blank'>https://hub.docker.com/r/doliana/logitech-media-server</a>, available for amd64 and arm64 architecture.</p>",
-		"more_info": "<h4>Update to newer version</h4><p>Due to some current <a href='https://github.com/rockstor/rockstor-core/issues/2209' target='_blank'>limitations in rock-on networking</a>, the web UI port of this rock-on must be set as 9000 and will thus prevent the installation of other rock-ons needing this port. Alternatively, the web UI can be accessed manually at http://rockstor-ip:9000</p><p>After first installation: to update to a newer stable version, either uninstall/reinstall the Rockon or use the Watchtower Rockon to manage the update of the underlying Media Server image, as it does not automatically update itself during a stop/restart of the Rockon like some other Rockons do. Don't use the update option within the LMS!</p><p>The LMS configuration files will remain in place on the volumes that were specified during the initial installation</p>",
-		"website": "https://mysqueezebox.com/",
-		"version": "2.3",
-		"ui": {
-			"slug": ""
-		},
-		"containers": {
-			"lms_latest": {
-				"image": "doliana/logitech-media-server",
-				"tag": "latest",
-				"launch_order": 1,
-				"opts": [
-					[
-						"--net",
-						"host"
-					]
-				],
-				"ports": {
-					"9000": {
-						"description": "WebUI port. This MUST be set to 9000",
-						"host_default": 9000,
-						"label": "WebUI port",
-						"protocol": "tcp",
-						"ui": true
-					},
-					"9090": {
-						"description": "Command Line Interface (used for example by Android app Squeezer). Suggested Default: 9090",
-						"host_default": 9090,
-						"label": "CLI port",
-						"protocol": "tcp"
-					},
-					"3483": {
-						"description": "control channel for LMS (display, IR, etc.), tcp and udp (SB --> Slimserver discovery and for older SLIMP3 players). Suggested Default: 3483",
-						"host_default": 3483,
-						"label": "Control Channel"
-					}
-				},
-				"volumes": {
-					"/srv/squeezebox": {
-						"description": "Choose a Share for LMS configuration. E.g.: create a Share called lms-config for this purpose alone.",
-						"label": "Config Storage"
-					},
-					"/srv/music": {
-						"description": "Choose a Share for LMS content(your media). E.g.: create a Share called lms-music for this purpose alone. You can also assign other media Shares on the system after installation.",
-						"label": "Data Storage"
-					}
-				}
-			}
-		}
-	}
+    "Lyrion Media Server - Latest Stable": {
+        "description": "Lyrion Media Server (formerly known as Logitech Media Server, Squeezebox, slimserver, etc.). Latest stable version. For future updates see more information icon after first installation.<p>Based on a official community docker image: <a href='https://hub.docker.com/r/lmscommunity/logitechmediaserver' target='_blank'>https://hub.docker.com/r/lmscommunity/logitechmediaserver</a>, available for amd64 and arm64 architecture.</p>",
+        "more_info": "<h4>Update to newer version</h4><p>Due to some current <a href='https://github.com/rockstor/rockstor-core/issues/2209' target='_blank'>limitations in rock-on networking</a>, the web UI port of this rock-on must be set as 9000 and will thus prevent the installation of other rock-ons needing this port. Alternatively, the web UI can be accessed manually at http://rockstor-ip:9000</p><p>After first installation: to update to a newer stable version, either uninstall/reinstall the Rockon or use the Watchtower Rockon to manage the update of the underlying Media Server image, as it does not automatically update itself during a stop/restart of the Rockon like some other Rockons do. Don't use the update option within the LMS!</p><p>The LMS configuration files will remain in place on the volumes that were specified during the initial installation</p>",
+        "website": "https://lyrion.org/",
+        "version": "2.4",
+        "ui": {
+            "slug": ""
+        },
+        "containers": {
+            "lms_latest": {
+                "image": "lmscommunity/logitechmediaserver",
+                "tag": "latest",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "--net",
+                        "host"
+                    ]
+                ],
+                "ports": {
+                    "9000": {
+                        "description": "WebUI port. This MUST be set to 9000",
+                        "host_default": 9000,
+                        "label": "WebUI port",
+                        "protocol": "tcp",
+                        "ui": true
+                    },
+                    "9090": {
+                        "description": "Command Line Interface (used for example by Android app Squeezer). Suggested Default: 9090",
+                        "host_default": 9090,
+                        "label": "CLI port",
+                        "protocol": "tcp"
+                    },
+                    "3483": {
+                        "description": "control channel for LMS (display, IR, etc.), tcp and udp (SB --> Slimserver discovery and for older SLIMP3 players). Suggested Default: 3483",
+                        "host_default": 3483,
+                        "label": "Control Channel"
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for LMS configuration. E.g.: create a Share called lms-config for this purpose alone.",
+                        "label": "Config Storage"
+                    },
+                    "/music": {
+                        "description": "Choose a Share for LMS content(your media). E.g.: create a Share called lms-music for this purpose alone. You can also assign other media Shares on the system after installation.",
+                        "label": "Media Storage"
+                    },
+                    "/playlist": {
+                        "description": "Choose a Share for LMS Playlists. E.g.: create a Share called lms-playlist for this purpose alone. You can also assign other media Shares on the system after installation.",
+                        "label": "Playlist Storage"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "description": "Enter a valid User ID (UID) to run Home Assistant with. It must have full permissions to all Shares mapped in the previous step.",
+                        "label": "UID",
+                        "index": 1
+                    },
+                    "PGID": {
+                        "description": "Enter a valid Group ID (GID) to use along with the above UID. It(or the above UID) must have full permissions to all Shares mapped in the previous step.",
+                        "label": "GID",
+                        "index": 2
+                    }
+                }
+            }
+        }
+    }
 }

--- a/lms_latest.json
+++ b/lms_latest.json
@@ -54,7 +54,7 @@
                 },
                 "environment": {
                     "PUID": {
-                        "description": "Enter a valid User ID (UID) to run Home Assistant with. It must have full permissions to all Shares mapped in the previous step.",
+                        "description": "Enter a valid User ID (UID) to run Lyrion Media Server with. It must have full permissions to all Shares mapped in the previous step.",
                         "label": "UID",
                         "index": 1
                     },

--- a/lms_latest.json
+++ b/lms_latest.json
@@ -27,7 +27,7 @@
                         "ui": true
                     },
                     "9090": {
-                        "description": "Command Line Interface (used for example by Android app Squeezer). Suggested Default: 9090",
+                        "description": "Command Line Interface (used for example by Android app Squeezer). This MUST be set to 9090",
                         "host_default": 9090,
                         "label": "CLI port",
                         "protocol": "tcp"


### PR DESCRIPTION
Fixes #381.

Changes performed:
- Replace Docker Image with new community version (renamed to Lyrion Media Server after Logitech shut project down).
- Update Parameter Changes/Description
- Formatting

### Information on docker image
- new docker image: [<link to image page on docker hub>](https://hub.docker.com/r/lmscommunity/logitechmediaserver/)
- is an official docker image available for this project?: Yes - project migrated from Logitech to community: https://lyrion.org/


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
