### PR TITLE
BareOS server set #94

### DIFF
--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -23,6 +23,12 @@
           "name": "bareos-webui-to-webui-php-fpm",
           "source_container": "bareos-webui-php-fpm"
         }
+      ],
+      "bareos-webui-php-fpm": [
+        {
+          "name": "bareos-webui-php-fpm-to-director",
+          "source_container": "bareos-director"
+        }
       ]
     },
     "containers": {

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -1,0 +1,162 @@
+{
+  "BareOS-server-set": {
+    "description": "BareOS Director/Catalogue/Storage server set. A comprehensive network-based open-source backup and recovery solution for all major operating systems.<p>Based on custom docker images: <a href='https://hub.docker.com/u/barcus/' target='_blank'>https://hub.docker.com/u/barcus/</a>, available for amd64 and arm64 architecture.</p>",
+    "version": "0.0.1",
+    "website": "https://www.bareos.org/",
+    "container_links": {
+      "bareos-director": [
+        {
+          "name": "bareos-director-to-db",
+          "source_container": "bareos-db"
+        },
+        {
+          "name": "bareos-director-to-storage",
+          "source_container": "bareos-storage"
+        },
+        {
+          "name": "bareos-director-to-webui",
+          "source_container": "bareos-webui"
+        }
+      ]
+    },
+    "containers": {
+      "bareos-db": {
+        "image": "postgres",
+        "tag": "14",
+        "launch_order": 1,
+        "volumes": {
+          "/var/lib/postgresql/data": {
+            "description": "BareOS 'Catalog' (Postgres DB) Share.",
+            "label": "'Catalog' data [e.g. bareos-catalog]"
+          }
+        },
+        "environment": {
+          "POSTGRES_PASSWORD": {
+            "description": "Set password for `postgres` super-user.",
+            "label": "'postgres' super-user password"
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "POSTGRES_INITDB_ARGS=--encoding=SQL_ASCII"
+          ]
+        ]
+      },
+      "bareos-director": {
+        "image": "barcus/bareos-director",
+        "tag": "latest",
+        "launch_order": 2,
+        "volumes": {
+          "/etc/bareos": {
+            "description": "BareOS 'Director' configuration Share.",
+            "label": "'Director' config [e.g. bareos-dir-config]"
+          },
+          "/var/lib/bareos": {
+            "description": "BareOS Catalog-Backup Share",
+            "label": "Catalog-backup data [e.g. bareos-catalog-backup]"
+          }
+        },
+        "ports": {
+          "9101": {
+            "description": "BareOS 'Director' communications port.",
+            "host_default": 9101,
+            "label": "Director port [must be 9101]",
+            "protocol": "tcp",
+            "ui": false
+          }
+        },
+        "environment": {
+          "DB_ADMIN_PASSWORD": {
+            "description": "Re-enter `postgres` super-user password.",
+            "label": "Re-enter 'postgres' super-user password"
+          },
+          "DB_PASSWORD": {
+            "description": "Set password for the `bareos` DB user.",
+            "label": "Catalog `bareos` user password"
+          },
+          "BAREOS_WEBUI_PASSWORD": {
+            "description": "Set BareOS Web-UI 'admin' user password.",
+            "label": "Web-UI 'admin' user's password"
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "DB_INIT=true"
+          ],
+          [
+            "-e",
+            "DB_NAME=bareos"
+          ],
+          [
+            "-e",
+            "DB_USER=bareos"
+          ],
+          [
+            "-e",
+            "DB_ADMIN_USER=postgres"
+          ],
+          [
+            "-e",
+            "DB_HOST=bareos-db"
+          ],
+          [
+            "-e",
+            "DB_PORT=5432"
+          ]
+        ]
+      },
+      "bareos-storage": {
+        "image": "barcus/bareos-storage",
+        "tag": "latest",
+        "launch_order": 3,
+        "volumes": {
+          "/etc/bareos": {
+            "description": "BareOS 'Storage' configuration Share.",
+            "label": "'Storage' config [e.g. bareos-storage-config]"
+          },
+          "/var/lib/bareos/storage": {
+            "description": "BareOS 'Storage' Share for all backups.",
+            "label": "Backups data [e.g. bareos-backups]"
+          }
+        },
+        "ports": {
+          "9103": {
+            "description": "BareOS 'Storage' communications port.",
+            "host_default": 9103,
+            "label": "Storage port [must be 9103]",
+            "protocol": "tcp",
+            "ui": false
+          }
+        }
+      },
+      "bareos-webui": {
+        "image": "barcus/bareos-webui",
+        "tag": "latest",
+        "launch_order": 4,
+        "volumes": {
+          "/etc/bareos-webui": {
+            "description": "BareOS 'WebUI' configuration Share.",
+            "label": "'WebUI' config [e.g. bareos-webui-config]"
+          }
+        },
+        "ports": {
+          "9100": {
+            "description": "BareOS Web Interface.",
+            "host_default": 9100,
+            "label": "WebUI port [e.g. 9100]",
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "SERVER_STATS=yes"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -75,6 +75,10 @@
             "description": "Set password for the `bareos` DB user.",
             "label": "Catalog `bareos` user password"
           },
+          "BAREOS_SD_PASSWORD": {
+            "description": "Set BareOS Storage service password.",
+            "label": "BareOS Storage password"
+          },
           "BAREOS_WEBUI_PASSWORD": {
             "description": "Set BareOS Web-UI 'admin' user password.",
             "label": "Web-UI 'admin' user's password"
@@ -104,6 +108,14 @@
           [
             "-e",
             "DB_PORT=5432"
+          ],
+          [
+            "-e",
+            "ADMIN_MAIL=root@localhost"
+          ],
+          [
+            "-e",
+            "WEBHOOK_NOTIFICATION=true"
           ]
         ]
       },
@@ -129,6 +141,12 @@
             "protocol": "tcp",
             "ui": false
           }
+        },
+        "environment": {
+          "BAREOS_SD_PASSWORD": {
+            "description": "Re-enter BareOS Storage service password.",
+            "label": "Re-enter BareOS Storage service password"
+          }
         }
       },
       "bareos-webui": {
@@ -151,6 +169,10 @@
           }
         },
         "opts": [
+          [
+            "-e",
+            "BAREOS_DIR_HOST=bareos-director"
+          ],
           [
             "-e",
             "SERVER_STATS=yes"

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -158,15 +158,21 @@
         "tag": "latest",
         "launch_order": 4,
         "volumes": {
+          "/usr/share/bareos-webui": {
+            "description": "BareOS 'WebUI' data Share.",
+            "label": "'WebUI' data [must be bareos-webui-data]"
+          },
           "/etc/bareos-webui": {
             "description": "BareOS 'WebUI' configuration Share.",
             "label": "'WebUI' config [e.g. bareos-webui-config]"
-          },
-          "/usr/share/bareos-webui": {
-            "description": "BareOS 'WebUI' data Share.",
-            "label": "'WebUI' data [e.g. bareos-webui-data]"
           }
-        }
+        },
+        "opts": [
+          [
+            "-v",
+            "/mnt2/bareos-webui-data:/var/www/html"
+          ]
+        ]
       },
       "bareos-webui": {
         "image": "barcus/bareos-webui",

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -16,9 +16,11 @@
         {
           "name": "bareos-director-to-webui",
           "source_container": "bareos-webui"
-        },
+        }
+      ],
+      "bareos-webui": [
         {
-          "name": "bareos-director-to-webui-php-fpm",
+          "name": "bareos-webui-to-webui-php-fpm",
           "source_container": "bareos-webui-php-fpm"
         }
       ]

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -1,6 +1,6 @@
 {
   "BareOS-server-set": {
-    "description": "BareOS Director/Catalogue/Storage server set. A comprehensive network-based open-source backup and recovery solution for all major operating systems.<p>Based on custom docker images: <a href='https://hub.docker.com/u/barcus/' target='_blank'>https://hub.docker.com/u/barcus/</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "BareOS Director/Catalog/Storage/File server set. A comprehensive network-based open-source backup and recovery solution for all major operating systems.<p>Based on custom docker images: <a href='https://hub.docker.com/u/barcus/' target='_blank'>https://hub.docker.com/u/barcus/</a>, available for amd64 and arm64 architecture.</p>",
     "version": "0.0.1",
     "website": "https://www.bareos.org/",
     "container_links": {
@@ -16,6 +16,10 @@
         {
           "name": "bareos-director-to-webui",
           "source_container": "bareos-webui"
+        },
+        {
+          "name": "bareos-director-to-file",
+          "source_container": "bareos-fd"
         }
       ],
       "bareos-webui": [
@@ -38,7 +42,7 @@
         "launch_order": 1,
         "volumes": {
           "/var/lib/postgresql/data": {
-            "description": "BareOS 'Catalog' (Postgres DB) Share.",
+            "description": "'Catalog' storage (Postgres DB) Share.",
             "label": "'Catalog' data [e.g. bareos-catalog]"
           }
         },
@@ -61,19 +65,23 @@
         "launch_order": 2,
         "volumes": {
           "/etc/bareos": {
-            "description": "BareOS 'Director' configuration Share.",
+            "description": "'Director' configuration Share.",
             "label": "'Director' config [e.g. bareos-dir-config]"
           },
           "/var/lib/bareos": {
-            "description": "BareOS Catalog-Backup Share",
-            "label": "Catalog-backup data [e.g. bareos-catalog-backup]"
+            "description": "'Director' data/state Share.",
+            "label": "'Director' data [e.g. bareos-dir-data]"
+          },
+          "/var/lib/bareos-director": {
+            "description": "'Catalog' backup Share",
+            "label": "Catalog-backup [must be bareos-catalog-backup]"
           }
         },
         "ports": {
           "9101": {
-            "description": "BareOS 'Director' communications port.",
+            "description": "'Director' communications port.",
             "host_default": 9101,
-            "label": "Director port [must be 9101]",
+            "label": "'Director' port [must be 9101]",
             "protocol": "tcp",
             "ui": false
           }
@@ -85,11 +93,15 @@
           },
           "DB_PASSWORD": {
             "description": "Set password for the `bareos` DB user.",
-            "label": "Catalog `bareos` user password"
+            "label": "Catalog's `bareos` user password"
           },
           "BAREOS_SD_PASSWORD": {
-            "description": "Set BareOS Storage service password.",
-            "label": "BareOS Storage password"
+            "description": "Set 'Storage' service password.",
+            "label": "'Storage' password"
+          },
+          "BAREOS_FD_PASSWORD": {
+            "description": "Set Director's local 'File'/Client service (bareos-fd) password.",
+            "label": "Director's local 'File' password"
           },
           "BAREOS_WEBUI_PASSWORD": {
             "description": "Set BareOS Web-UI 'admin' user password.",
@@ -123,6 +135,14 @@
           ],
           [
             "-e",
+            "BAREOS_SD_HOST=bareos-storage"
+          ],
+          [
+            "-e",
+            "BAREOS_FD_HOST=bareos-fd"
+          ],
+          [
+            "-e",
             "ADMIN_MAIL=root@localhost"
           ],
           [
@@ -137,34 +157,61 @@
         "launch_order": 3,
         "volumes": {
           "/etc/bareos": {
-            "description": "BareOS 'Storage' configuration Share.",
+            "description": "'Storage' service configuration Share.",
             "label": "'Storage' config [e.g. bareos-storage-config]"
           },
           "/var/lib/bareos/storage": {
-            "description": "BareOS 'Storage' Share for all backups.",
+            "description": "'Storage' data Share for all backups.",
             "label": "Backups data [e.g. bareos-backups]"
           }
         },
         "ports": {
           "9103": {
-            "description": "BareOS 'Storage' communications port.",
+            "description": "'Storage' communications port.",
             "host_default": 9103,
-            "label": "Storage port [must be 9103]",
+            "label": "'Storage' port [must be 9103]",
             "protocol": "tcp",
             "ui": false
           }
         },
         "environment": {
           "BAREOS_SD_PASSWORD": {
-            "description": "Re-enter BareOS Storage service password.",
-            "label": "Re-enter BareOS Storage password"
+            "description": "Re-enter 'Storage' service password.",
+            "label": "Re-enter 'Storage' password"
           }
         }
+      },
+      "bareos-fd": {
+        "image": "barcus/bareos-client",
+        "tag": "latest",
+        "launch_order": 4,
+        "volumes": {
+          "/etc/bareos": {
+            "description": "Director's local 'File'/Client service configuration Share.",
+            "label": "Director's local 'File' config [e.g. bareos-file-config]"
+          }
+        },
+        "environment": {
+          "BAREOS_FD_PASSWORD": {
+            "description": "Re-enter Director's local 'File'/client service (bareos-fd) password.",
+            "label": "Re-enter Director's local 'File' password"
+          }
+        },
+        "opts": [
+          [
+            "-v",
+            "/mnt2/bareos-catalog-backup:/var/lib/bareos-director"
+          ],
+          [
+            "-e",
+            "FORCE_ROOT=false"
+          ]
+        ]
       },
       "bareos-webui-php-fpm": {
         "image": "barcus/php-fpm-alpine",
         "tag": "latest",
-        "launch_order": 4,
+        "launch_order": 5,
         "volumes": {
           "/usr/share/bareos-webui": {
             "description": "BareOS 'WebUI' data Share.",
@@ -185,7 +232,7 @@
       "bareos-webui": {
         "image": "barcus/bareos-webui",
         "tag": "latest",
-        "launch_order": 5,
+        "launch_order": 6,
         "ports": {
           "9100": {
             "description": "BareOS Web Interface.",

--- a/bareos-server-set.json
+++ b/bareos-server-set.json
@@ -16,6 +16,10 @@
         {
           "name": "bareos-director-to-webui",
           "source_container": "bareos-webui"
+        },
+        {
+          "name": "bareos-director-to-webui-php-fpm",
+          "source_container": "bareos-webui-php-fpm"
         }
       ]
     },
@@ -145,20 +149,29 @@
         "environment": {
           "BAREOS_SD_PASSWORD": {
             "description": "Re-enter BareOS Storage service password.",
-            "label": "Re-enter BareOS Storage service password"
+            "label": "Re-enter BareOS Storage password"
           }
         }
       },
-      "bareos-webui": {
-        "image": "barcus/bareos-webui",
+      "bareos-webui-php-fpm": {
+        "image": "barcus/php-fpm-alpine",
         "tag": "latest",
         "launch_order": 4,
         "volumes": {
           "/etc/bareos-webui": {
             "description": "BareOS 'WebUI' configuration Share.",
             "label": "'WebUI' config [e.g. bareos-webui-config]"
+          },
+          "/usr/share/bareos-webui": {
+            "description": "BareOS 'WebUI' data Share.",
+            "label": "'WebUI' data [e.g. bareos-webui-data]"
           }
-        },
+        }
+      },
+      "bareos-webui": {
+        "image": "barcus/bareos-webui",
+        "tag": "latest",
+        "launch_order": 5,
         "ports": {
           "9100": {
             "description": "BareOS Web Interface.",
@@ -172,6 +185,18 @@
           [
             "-e",
             "BAREOS_DIR_HOST=bareos-director"
+          ],
+          [
+            "-e",
+            "PHP_FPM_HOST=bareos-webui-php-fpm"
+          ],
+          [
+            "-e",
+            "PHP_FPM_PORT=9000"
+          ],
+          [
+            "--volumes-from",
+            "bareos-webui-php-fpm"
           ],
           [
             "-e",

--- a/root.json
+++ b/root.json
@@ -1,6 +1,7 @@
 {
     "2FAuth": "2FAuth.json",
     "Airsonic Advanced": "airsonic-advanced.json",
+    "BareOS-server-set": "bareos-server-set.json",
     "Booksonic": "booksonic.json",
     "Collabora Online": "collabora-online.json",
     "COPS": "cops.json",


### PR DESCRIPTION
Multi Container BareOS server set Rock-on.

## Containing:
- Director Service (Overall controller).
- Catalog Service (Postgres DB for Director).
- Storage Service (Back-end Storage for Director and File (client) services).
- Web-UI Service (Director interface).

Fixes #94 

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: BareOS
- website: https://www.bareos.org
- description:  A comprehensive network-based open-source backup and recovery solution for all major operating systems

### Information on docker image/s
- docker image: Uses custom docker images at https://hub.docker.com/u/barcus/ as no official docker images are available.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the images particulars
- [x] `"website"` object links to project's main website

