### PR TITLE
Replace deprecated clear text password with hash

### DIFF
--- a/WireGuardEasy.json
+++ b/WireGuardEasy.json
@@ -1,94 +1,94 @@
 {
-	"WireGuard Easy": {
-		"containers": {
-			"WireGuardEasy": {
-				"image": "ghcr.io/wg-easy/wg-easy",
-				"launch_order": 1,
-				"opts": [
-					[
-						"--cap-add",
-						"NET_ADMIN"
-					],
-					[
-						"--cap-add",
-						"SYS_MODULE"
-					],
-					[
-						"--sysctl",
-						"net.ipv4.conf.all.src_valid_mark=1"
-					],
-					[
-						"--sysctl",
-						"net.ipv4.ip_forward=1"
-					]
-				],
-				"ports": {
-					"51820": {
-						"description": "Wireguard port. Suggested default: 51820",
-						"host_default": 51820,
-						"label": "Wireguard Port (udp)",
-						"protocol": "udp",
-						"ui": false
-					},
-					"51821": {
-						"description": "Wireguard WebUI port. Suggested default: 51821",
-						"host_default": 51821,
-						"label": "Wireguard WebUI Port (tcp)",
-						"protocol": "tcp",
-						"ui": true
-					}
-				},
-				"volumes": {
-					"/etc/wireguard": {
-						"description": "Choose a Share to store the WireGuard configuration. E.g.: create a Share called wireguard-config for this purpose alone.",
-						"label": "Wireguard Easy Config Storage"
-					}
-				},
-				"environment": {
-					"WG_HOST": {
-						"description": "Enter your WAN IP (externally visible IP), or a Dynamic DNS hostname (e.g.: vpn.myserver.com)",
-						"label": "WAN IP",
-						"index": 1
-					},
-					"PASSWORD": {
-						"description": "Enter an administrator password to log into the WebUI",
-						"label": "WebUI Password",
-						"index": 2
-					},
-					"WG_DEVICE": {
-						"description": "Ethernet device the wireguard traffic should be forwarded through (e.g.: ens6f0). For default enter value: eth0",
-						"label": "Ethernet Device",
-						"index": 3
-					},
-					"WG_DEFAULT_ADDRESS": {
-						"description": "Clients' IP address range, using x for the last octet (e.g.: 10.6.0.x). For default enter value: 10.8.0.x",
-						"label": "Client Address Space",
-						"index": 4
-					},
-					"WG_DEFAULT_DNS": {
-						"description": "DNS server(s) clients will use, separated by commas (e.g.: 8.8.8.8, 8.8.4.4). For default enter value: 1.1.1.1",
-						"label": "Default DNS Server",
-						"index": 5
-					},
-					"WG_ALLOWED_IPS": {
-						"description": "Allowed IPs clients will use, separated by commas (e.g.: 192.168.15.0/24, 10.0.1.0/24). For no restrictions enter values: 0.0.0.0/0, ::/0",
-						"label": "Allowed IP address ranges",
-						"index": 6
-					},
-					"WG_PERSISTENT_KEEPALIVE": {
-						"description": "Value in seconds to keep the connection open. If this value is set to 0, then the PersistenKeepalive functionality is turned off. For default enter value: 0.",
-						"label": "Persistent Keepalive (second)",
-						"index": 7
-					}
-				}
-			}
-		},
-		"description": "<p>The easiest way to run WireGuard VPN + Web-based Admin UI.</p><p>Based on the custom docker image by <a href='https://github.com/WeeJeWel' target='_blank'>Emile Nijssen</a>: <a href='https://github.com/wg-easy/wg-easy/pkgs/container/wg-easy' target='_blank'>https://github.com/wg-easy/wg-easy/pkgs/container/wg-easy</a>, available for amd64 and arm64 architecture.</p>",
-		"ui": {
-			"slug": ""
-		},
-		"volume_add_support": false,
-		"website": "https://www.wireguard.com/",
-		"version": "1.1"
-	}
+    "WireGuard Easy": {
+        "containers": {
+            "WireGuardEasy": {
+                "image": "ghcr.io/wg-easy/wg-easy",
+                "launch_order": 1,
+                "opts": [
+                    [
+                        "--cap-add",
+                        "NET_ADMIN"
+                    ],
+                    [
+                        "--cap-add",
+                        "SYS_MODULE"
+                    ],
+                    [
+                        "--sysctl",
+                        "net.ipv4.conf.all.src_valid_mark=1"
+                    ],
+                    [
+                        "--sysctl",
+                        "net.ipv4.ip_forward=1"
+                    ]
+                ],
+                "ports": {
+                    "51820": {
+                        "description": "Wireguard port. Suggested default: 51820",
+                        "host_default": 51820,
+                        "label": "Wireguard Port (udp)",
+                        "protocol": "udp",
+                        "ui": false
+                    },
+                    "51821": {
+                        "description": "Wireguard WebUI port. Suggested default: 51821",
+                        "host_default": 51821,
+                        "label": "Wireguard WebUI Port (tcp)",
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/etc/wireguard": {
+                        "description": "Choose a Share to store the WireGuard configuration. E.g.: create a Share called wireguard-config for this purpose alone.",
+                        "label": "Wireguard Easy Config Storage"
+                    }
+                },
+                "environment": {
+                    "WG_HOST": {
+                        "description": "Enter your WAN IP (externally visible IP), or a Dynamic DNS hostname (e.g.: vpn.myserver.com)",
+                        "label": "WAN IP",
+                        "index": 1
+                    },
+                    "PASSWORD_HASH": {
+                        "description": "Enter an administrator password hash to log into the WebUI (see Rockon description for instruction link)",
+                        "label": "WebUI administrator password hash",
+                        "index": 2
+                    },
+                    "WG_DEVICE": {
+                        "description": "Ethernet device the wireguard traffic should be forwarded through (e.g.: ens6f0). For default enter value: eth0",
+                        "label": "Ethernet Device",
+                        "index": 3
+                    },
+                    "WG_DEFAULT_ADDRESS": {
+                        "description": "Clients' IP address range, using x for the last octet (e.g.: 10.6.0.x). For default enter value: 10.8.0.x",
+                        "label": "Client Address Space",
+                        "index": 4
+                    },
+                    "WG_DEFAULT_DNS": {
+                        "description": "DNS server(s) clients will use, separated by commas (e.g.: 8.8.8.8, 8.8.4.4). For default enter value: 1.1.1.1",
+                        "label": "Default DNS Server",
+                        "index": 5
+                    },
+                    "WG_ALLOWED_IPS": {
+                        "description": "Allowed IPs clients will use, separated by commas (e.g.: 192.168.15.0/24, 10.0.1.0/24). For no restrictions enter values: 0.0.0.0/0, ::/0",
+                        "label": "Allowed IP address ranges",
+                        "index": 6
+                    },
+                    "WG_PERSISTENT_KEEPALIVE": {
+                        "description": "Value in seconds to keep the connection open. If this value is set to 0, then the PersistenKeepalive functionality is turned off. For default enter value: 0.",
+                        "label": "Persistent Keepalive (second)",
+                        "index": 7
+                    }
+                }
+            }
+        },
+        "description": "<p>The easiest way to run WireGuard VPN + Web-based Admin UI.</p><p>Based on the custom docker image by <a href='https://github.com/WeeJeWel' target='_blank'>Emile Nijssen</a>: <a href='https://github.com/wg-easy/wg-easy/pkgs/container/wg-easy' target='_blank'>ghcr.io/wg-easy/wg-easy</a>, available for amd64 and arm64 architecture.</p><p>Note that an administrator password hash is needed instead of using a clear text password during the Rockon configuration. Use instructions found <a href='https://github.com/wg-easy/wg-easy/blob/master/How_to_generate_an_bcrypt_hash.md' target='_blank'>here</a> to generate a bcrypt password hash based on your own WebUI administrator password  and enter the resulting password hash without quotes.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": false,
+        "website": "https://www.wireguard.com/",
+        "version": "1.5"
+    }
 }


### PR DESCRIPTION
Fixes #388 .

### General information on project
- The developer deprecated clear text password earlier this year with a hash password that can be generated based on a script they are providing.
### Information on docker image
same author, however, the developer is recommending to use the image on Github instead of Docker hub:
ghcr.io/wg-easy/wg-easy

### Changes made to update Rockon definition:
- update image source
- replace password parameter with password hash parameter
- update description with instructions for hash.
- fix indentation formatting (tab to space)
- increased version number

### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website

### Testing
I have installed it using the same parameters as before, with the exception of the password now being entered as a hash value. Works well for me, connectivity from outside the network operates just as before it broke. The admin WebUI is accessible with the underlying password, so that transition works as well.