### PR TITLE
Creates a Rockon for the IDS NetAlertX

### DIFF
--- a/netalertx.json
+++ b/netalertx.json
@@ -37,7 +37,7 @@
                                 }
                         }
                 },
-                "description": "NetAlertX is an intrusion detection system (IDS).<p>Easily visualize all your networks in one place, enhance security with real-time alerts, and enjoy seamless integration with your smart home—no matter what hardware you use.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/jokobsk/netalertx' target='_blank'>https://hub.docker.com/r/jokobsk/netalertx</a>, available for amd64, arm64, armv7 and armv6 architecture.</p>",
+                "description": "NetAlertX is an intrusion detection system (IDS).<p>Easily visualize all your networks in one place, enhance security with real-time alerts, and enjoy seamless integration with your smart home — no matter what hardware you use.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/jokobsk/netalertx' target='_blank'>https://hub.docker.com/r/jokobsk/netalertx</a>, available for amd64 and arm64 architecture.</p>",
                 "more_info": "<h4>NetAlertX</h4><p><b>Admin page</b></p><p>To access admin interface go to URL: http://[SERVERIP]:[Web-Port]</p><p>Note: this Rockon uses the net=host option.",
                 "volume_add_support": true,
                 "website": "https://netalertx.com/",

--- a/netalertx.json
+++ b/netalertx.json
@@ -14,7 +14,7 @@
                                     "20211": {
                                         "description": "Rockon UI Link Port. Recommended: 20211. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rockon page.",
                                         "host_default": 20211,
-                                        "label": "Rockon_Web-Port",
+                                        "label": "Rockon Web Port",
                                         "ui": true
                                     }
                                 },

--- a/netalertx.json
+++ b/netalertx.json
@@ -1,0 +1,46 @@
+{
+        "NetAlertX": {
+                "containers": {
+                        "netalertx": {
+                                "image": "jokobsk/netalertx",
+                                "opts": [
+                                        [
+                                                "--net",
+                                                "host"
+                                        ]
+                                ],
+                                "launch_order": 1,
+                                "ports": {
+                                    "20211": {
+                                        "description": "Rockon UI Link Port. Recommended: 20211. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rocko
+                                        "host_default": 20211,
+                                        "label": "Rockon_Web-Port",
+                                        "ui": true
+                                    }
+                                },
+                                "volumes": {
+                                        "/app/config": {
+                                                "description": "Choose a share for NetAlertX configuration. E.g.: create a Share called netalertx-config for this purpose alone.",
+                                                "label": "NetAlertX config"
+                                        },
+                                        "/app/db": {
+                                                "description": "Choose a share for NetAlertX database. E.g.: create a Share called netalertx-db for this purpose alone.",
+                                                "label": "NetAlertX db"
+                                        }
+                                },
+                                "environment": {
+                                        "PORT": {
+                                                "description": "Enter the WebUI Web-port number. Recommended: 20211. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for pi-ho
+                                                "label": "Web-Port",
+                                                "index": 1
+                                        }
+                                }
+                        }
+                },
+                "description": "NetAlertX is an intrusion detection system (IDS).<p>Easily visualize all your networks in one place, enhance security with real-time alerts, and enjoy seamless integration with your smart home—no matter wh
+                "more_info": "<h4>NetAlertX</h4><p><b>Admin page</b></p><p>To access admin interface go to URL: http://[SERVERIP]:[Web-Port]</p><p>Note: this Rockon uses the net=host option.",
+                "volume_add_support": true,
+                "website": "https://netalertx.com/",
+                "version": "1.0"
+        }
+}

--- a/netalertx.json
+++ b/netalertx.json
@@ -12,7 +12,7 @@
                                 "launch_order": 1,
                                 "ports": {
                                     "20211": {
-                                        "description": "Rockon UI Link Port. Recommended: 20211. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rocko
+                                        "description": "Rockon UI Link Port. Recommended: 20211. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rockon page.",
                                         "host_default": 20211,
                                         "label": "Rockon_Web-Port",
                                         "ui": true
@@ -30,14 +30,14 @@
                                 },
                                 "environment": {
                                         "PORT": {
-                                                "description": "Enter the WebUI Web-port number. Recommended: 20211. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for pi-ho
+                                                "description": "Enter the WebUI Web-port number. Recommended: 20211. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for NetAlertX are accessible via Web Browser",
                                                 "label": "Web-Port",
                                                 "index": 1
                                         }
                                 }
                         }
                 },
-                "description": "NetAlertX is an intrusion detection system (IDS).<p>Easily visualize all your networks in one place, enhance security with real-time alerts, and enjoy seamless integration with your smart home—no matter wh
+                "description": "NetAlertX is an intrusion detection system (IDS).<p>Easily visualize all your networks in one place, enhance security with real-time alerts, and enjoy seamless integration with your smart home—no matter what hardware you use.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/jokobsk/netalertx' target='_blank'>https://hub.docker.com/r/jokobsk/netalertx</a>, available for amd64, arm64, armv7 and armv6 architecture.</p>",
                 "more_info": "<h4>NetAlertX</h4><p><b>Admin page</b></p><p>To access admin interface go to URL: http://[SERVERIP]:[Web-Port]</p><p>Note: this Rockon uses the net=host option.",
                 "volume_add_support": true,
                 "website": "https://netalertx.com/",

--- a/netalertx.json
+++ b/netalertx.json
@@ -31,7 +31,7 @@
                                 "environment": {
                                         "PORT": {
                                                 "description": "Enter the WebUI Web-port number. Recommended: 20211. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for NetAlertX are accessible via Web Browser",
-                                                "label": "Web-Port",
+                                                "label": "NetAlertX Web Port",
                                                 "index": 1
                                         }
                                 }

--- a/root.json
+++ b/root.json
@@ -40,6 +40,7 @@
     "MinIO": "minio.json",
     "Muximux": "Muximux.json",
     "Mylar": "mylar3.json",
+    "NetAlertX": "netalertx.json",
     "Netbootxyz": "netbootxyz.json",
     "Netdata (official)": "netdata-official.json",
     "Nextcloud-Official": "nextcloud-official.json",


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))

Fixes #396  .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: NetAlertX
- website: https://netalertx.com/
- description: It is a IDS and it uses net=host. It has a WebUI reminiscent of pi-hole.

### Information on docker image
- docker image: https://hub.docker.com/r/jokobsk/netalertx
- is an official docker image available for this project?: Yes.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
