### PR TITLE
paperless-ngx for use with an proxy like nginx

### DIFF
--- a/paperless-ngx.json
+++ b/paperless-ngx.json
@@ -70,6 +70,21 @@
                         "description": "This will be the password of the automatically created superuser.",
                         "label": "Superuser password",
                         "index": 3
+                    },
+                    "PAPERLESS_SECRET_KEY": {
+                        "description": "Adjust this key if you plan to make paperless available publicly.",
+                        "label": "Paperless Secretkey",
+                        "index": 4                        
+                    },
+                    "PAPERLESS_URL" : {
+                        "description": "This is required if you will be exposing Paperless-ngx on a public domain. E.g. https://paperless.domain.com",
+                        "label": "Paperless URL",
+                        "index": 5  
+                    },
+                    "PAPERLESS_CSRF_TRUSTED_ORIGINS" : {
+                        "description": "Set to the value of Paperless URL",
+                        "label": "CSRF Trusted Origins",
+                        "index": 6                          
                     }
                 }
             },


### PR DESCRIPTION
For use after optional Environment-Vars are possible.

### General information on project
This pull request proposes to udapte an rock-on for the following project:
- name: paperless-ngx
- website: https://docs.paperless-ngx.com/
- description:  I wanted to add with #405 additional environment-vars which are needed if using paperless-ngx with an proxy. Without `PAPERLESS_URL` and `PAPERLESS_CSRF_TRUSTED_ORIGINS` an upload not using the ip adress leads into an Http Error 403. See (https://github.com/paperless-ngx/paperless-ngx/discussions/6216)

### Information on docker image
- docker image: https://github.com/paperless-ngx/paperless-ngx
- is an official docker image available for this project?: yes


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
- [ ] Optional environment are possible 
