### PR TITLE
Switch to official Gollum image (#410)

### DIFF
--- a/gollum.json
+++ b/gollum.json
@@ -1,24 +1,25 @@
 {
-    "Gollum": {
-        "description": "A Git Based Wiki on Alpine. <p>Based on the official docker image: <a href='https://hub.docker.com/r/gollumwiki/gollum' target='_blank'>https://hub.docker.com/r/gollumwiki/gollum</a>, available for amd64 and arm64 architecture.</p>",
-        "version": "1.0",
+    "gollum": {
+        "description": "Gollum is a simple wiki system built on top of Git.<p>Based on the official docker image: <a href='https://hub.docker.com/r/gollumwiki/gollum' target='_blank'>https://hub.docker.com/r/gollumwiki/gollum</a>, available for amd64 and arm64 architecture.</p>",
+        "version": "1.1",
         "website": "https://github.com/gollum/gollum",
         "containers": {
-            "gollum-alpine": {
+            "gollumdw": {
                 "image": "gollumwiki/gollum",
+                "tag": "5.3",
                 "launch_order": 1,
                 "ports": {
                     "4567": {
                         "description": "Website Port",
                         "label": "Gollum Port",
-                        "host_default": 8082,
+                        "host_default": 4567,
                         "protocol": "tcp",
                         "ui": true
                     }
                 },
                 "volumes": {
                     "/wiki": {
-                        "description": "Choose a share for wiki storage. E.g. a create a share called gollum-wiki-storage.",
+                        "description": "Choose a share for the storage of artefacts created with gollum. E.g. a create a share called gollum-wiki.",
                         "label": "Wiki storage"
                     }
                 }

--- a/gollum.json
+++ b/gollum.json
@@ -1,11 +1,11 @@
 {
     "Gollum": {
-        "description": "A Git Based Wiki on Alpine. <p>Based on a custom docker image: <a href='https://hub.docker.com/r/adtac/gollum-alpine' target='_blank'>https://hub.docker.com/r/adtac/gollum-alpine</a>, available for amd64 architecture only.</p>",
-        "version": "0.0.2",
+        "description": "A Git Based Wiki on Alpine. <p>Based on the official docker image: <a href='https://hub.docker.com/r/gollumwiki/gollum' target='_blank'>https://hub.docker.com/r/gollumwiki/gollum</a>, available for amd64 and arm64 architecture.</p>",
+        "version": "1.0",
         "website": "https://github.com/gollum/gollum",
         "containers": {
             "gollum-alpine": {
-                "image": "adtac/gollum-alpine",
+                "image": "gollumwiki/gollum",
                 "launch_order": 1,
                 "ports": {
                     "8080": {
@@ -18,7 +18,7 @@
                 },
                 "volumes": {
                     "/wiki": {
-                        "description": "Choose a share for wiki storage",
+                        "description": "Choose a share for wiki storage. E.g. a create a share called gollum-wiki-storage.",
                         "label": "Wiki storage"
                     }
                 }

--- a/gollum.json
+++ b/gollum.json
@@ -8,7 +8,7 @@
                 "image": "gollumwiki/gollum",
                 "launch_order": 1,
                 "ports": {
-                    "8080": {
+                    "4567": {
                         "description": "Website Port",
                         "label": "Gollum Port",
                         "host_default": 8082,


### PR DESCRIPTION
- update docker image
- update descriptions

Fixes #410  .

### Information on docker image
- docker image: https://hub.docker.com/r/gollumwiki/gollum
- is an official docker image available for this project?: yes, switching to official image with this PR


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
