### PR TITLE
Update pi-hole to version 6.x (#427)

### DIFF
--- a/pi-hole.json
+++ b/pi-hole.json
@@ -14,7 +14,7 @@
                     ],
                     [
                         "-e",
-                        "FTLCONF_misc_etc_dnsmasq_d: 'true'"
+                        "FTLCONF_misc_etc_dnsmasq_d=true"
                     ]
                 ],
                 "launch_order": 1,

--- a/pi-hole.json
+++ b/pi-hole.json
@@ -1,7 +1,7 @@
 {
-    "Pi-Hole": {
+    "Pi-Holev6": {
         "containers": {
-            "pi-hole": {
+            "pi-holev6": {
                 "image": "pihole/pihole",
                 "opts": [
                     [
@@ -15,6 +15,10 @@
                     [
                         "-e",
                         "FTLCONF_misc_etc_dnsmasq_d=true"
+                    ],
+                    [
+                        "-e",
+                        "DNSMASQ_USER=root"
                     ]
                 ],
                 "launch_order": 1,
@@ -32,7 +36,7 @@
                         "label": "Pi-Hole config"
                     },
                     "/etc/dnsmasq.d": {
-                        "description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone.",
+                        "description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone. The share needs to have full access for a user with a corresponding UID=1000",
                         "label": "dnsmasq config"
                     }
                 },
@@ -46,12 +50,22 @@
                         "description": "Enter desired password for the pi-hole Web administration.",
                         "label": "Web Password",
                         "index": 2
-                    }
+                    },
+                    "PIHOLE_UID": {
+                         "description": "Enter a valid UID to run pi-hole with. It must have full permissions to the Pi-Hole configuration share mapped in the previous step.",
+                         "label": "pi-hole UID",
+                         "index": 3
+                   },
+                    "PIHOLE_GID": {
+                         "description": "Enter a valid GID to run pi-hole with. It must have full permissions to the pi-hole configuration share mapped in the previous step.",
+                         "label": "pi-hole GID",
+                         "index": 4
+                   }
                 }
             }
         },
         "description": "DNS Server that acts as a black hole for Internet advertisements.<p>Based on the official docker image: <a href='https://hub.docker.com/r/pihole/pihole' target='_blank'>https://hub.docker.com/r/pihole/pihole</a>, available for amd64 and arm64 architecture.</p>",
-        "more_info": "<h4>PI-HOLE™: A BLACK HOLE FOR INTERNET ADVERTISEMENTS</h4><p><p><b>Block Over 100,000 Ad-serving Domains</b></p><p>Known ad-serving domains are pulled from third party sources and compiled into one list.</p><p><b>Block Advertisements On Any Device</b></p><p>Network-level blocking allows any device to block ads, regardless of hardware or OS.</p><p><b>Improve Overall Network Performance</b></p><p>Since ads are blocked before they are downloaded, your network will perform better.</p><p>Note: this Rockon uses the net=host option to allow for use of the dhcp functionality.",
+        "more_info": "<h4>PI-HOLE™: A BLACK HOLE FOR INTERNET ADVERTISEMENTS</h4><p><p><b>Block Over 100,000 Ad-serving Domains</b></p><p>Known ad-serving domains are pulled from third party sources and compiled into one list.</p><p><b>Block Advertisements On Any Device</b></p><p>Network-level blocking allows any device to block ads, regardless of hardware or OS.</p><p><b>Improve Overall Network Performance</b></p><p>Since ads are blocked before they are downloaded, your network will perform better.</p><p>Note: this Rockon uses the net=host option to allow for use of the dhcp functionality. Also the dnsmasq user runs as root so it is able to access additional configuration in the dnsmasq.d directory",
         "volume_add_support": false,
             "ui": {
                 "slug": "admin"

--- a/pi-hole.json
+++ b/pi-hole.json
@@ -36,7 +36,7 @@
                         "label": "Pi-Hole config"
                     },
                     "/etc/dnsmasq.d": {
-                        "description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone. The share needs to have full access for a user with a corresponding UID=1000",
+                        "description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone and place any specific dnsmasq confguration you want to preset without using the WebUI.",
                         "label": "dnsmasq config"
                     }
                 },

--- a/pi-hole.json
+++ b/pi-hole.json
@@ -1,7 +1,7 @@
 {
-    "Pi-Holev6": {
+    "Pi-Hole": {
         "containers": {
-            "pi-holev6": {
+            "pi-hole": {
                 "image": "pihole/pihole",
                 "opts": [
                     [

--- a/pi-hole.json
+++ b/pi-hole.json
@@ -1,75 +1,62 @@
 {
-	"Pi-Hole": {
-		"containers": {
-			"pi-hole": {
-				"image": "pihole/pihole",
-				"opts": [
-					[
-						"--cap-add",
-						"NET_ADMIN"
-					],
-					[
-						"--dns",
-						"127.0.0.1"
-					],
-					[
-						"--dns",
-						"8.8.8.8"
-					],
-					[
-						"--net",
-						"host"
-					],
-					[
-						"-e",
-						"IPv6=False"
-					]
-				],
-				"launch_order": 1,
-				"ports": {
+    "Pi-Hole": {
+        "containers": {
+            "pi-hole": {
+                "image": "pihole/pihole",
+                "opts": [
+                    [
+                        "--cap-add",
+                        "NET_ADMIN"
+                    ],
+                    [
+                        "--net",
+                        "host"
+                    ],
+                    [
+                        "-e",
+                        "FTLCONF_misc_etc_dnsmasq_d: 'true'"
+                    ]
+                ],
+                "launch_order": 1,
+                "ports": {
                     "80": {
-                        "description": "Rockon UI Link Port. Recommended: 80. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rockon page.",
-                        "host_default": 80,
-                        "label": "Rockon_Web-Port",
+                        "description": "Rockon UI Link Port. Recommended: 8080. This port has to be the same as the subsequent Web-port later in the configuration, so the admin pages can be accessed from within the Rockon page.",
+                        "host_default": 8080,
+                        "label": "Rockon Web Port",
                         "ui": true
                     }
                 },
-				"volumes": {
-					"/etc/pihole": {
-						"description": "Choose a share for Pi-Hole configuration. E.g.: create a Share called pihole-config for this purpose alone.",
-						"label": "Pi-Hole config"
-					},
-					"/etc/dnsmasq.d": {
-						"description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone.",
-						"label": "dnsmasq config"
-					}
-				},
-				"environment": {
-					"FTLCONF_LOCAL_IPV4": {
-						"description": "Enter the IPv4 address of the Rockstor host. If not specified, it will default to the internal docker IP and will not work.",
-						"label": "Rockstor IP",
-						"index": 1
-					},
-					"WEB_PORT": {
-						"description": "Enter the WebUI Web-port number. Recommended: 80. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for pi-hole are accessible via Web Browser",
-						"label": "Web-Port",
-						"index": 2
-					},
-					"WEBPASSWORD": {
-						"description": "Enter desired password for the pi-hole Web administration.",
-						"label": "Web-Password",
-						"index": 3
-					}
-				}
-			}
-		},
-		"description": "DNS Server that acts as a black hole for Internet advertisements.<p>Based on the official docker image: <a href='https://hub.docker.com/r/pihole/pihole' target='_blank'>https://hub.docker.com/r/pihole/pihole</a>, available for amd64 and arm64 architecture.</p>",
-		"more_info": "<h4>PI-HOLE™: A BLACK HOLE FOR INTERNET ADVERTISEMENTS</h4><p><b>Admin page</b></p><p>To access admin interface go to URL: http://[SERVERIP]:[Web-Port]/Admin</p><p><b>Block Over 100,000 Ad-serving Domains</b></p><p>Known ad-serving domains are pulled from third party sources and compiled into one list.</p><p><b>Block Advertisements On Any Device</b></p><p>Network-level blocking allows any device to block ads, regardless of hardware or OS.</p><p><b>Improve Overall Network Performance</b></p><p>Since ads are blocked before they are downloaded, your network will perform better.</p><p>Note: this Rockon uses the net=host option to allow for use of the dhcp functionality.",
-		"volume_add_support": false,
-        	"ui": {
-            	"slug": "admin"
-        	},		
-		"website": "https://pi-hole.net/",
-		"version": "2.5"
-	}
+                "volumes": {
+                    "/etc/pihole": {
+                        "description": "Choose a share for Pi-Hole configuration. E.g.: create a Share called pihole-config for this purpose alone.",
+                        "label": "Pi-Hole config"
+                    },
+                    "/etc/dnsmasq.d": {
+                        "description": "Choose a share for dnsmasq configuration. E.g.: create a Share called dnsmasq-config for this purpose alone.",
+                        "label": "dnsmasq config"
+                    }
+                },
+                "environment": {
+                    "FTLCONF_webserver_port": {
+                        "description": "Enter the pi-hole WebUI Web-port number. Recommended: 8080. This port has to be the same as the Rockon UI Link port, configured earlier. This ensures that the admin pages for pi-hole are accessible via Web Browser",
+                        "label": "Web Port",
+                        "index": 1
+                    },
+                    "FTLCONF_webserver_api_password": {
+                        "description": "Enter desired password for the pi-hole Web administration.",
+                        "label": "Web Password",
+                        "index": 2
+                    }
+                }
+            }
+        },
+        "description": "DNS Server that acts as a black hole for Internet advertisements.<p>Based on the official docker image: <a href='https://hub.docker.com/r/pihole/pihole' target='_blank'>https://hub.docker.com/r/pihole/pihole</a>, available for amd64 and arm64 architecture.</p>",
+        "more_info": "<h4>PI-HOLE™: A BLACK HOLE FOR INTERNET ADVERTISEMENTS</h4><p><p><b>Block Over 100,000 Ad-serving Domains</b></p><p>Known ad-serving domains are pulled from third party sources and compiled into one list.</p><p><b>Block Advertisements On Any Device</b></p><p>Network-level blocking allows any device to block ads, regardless of hardware or OS.</p><p><b>Improve Overall Network Performance</b></p><p>Since ads are blocked before they are downloaded, your network will perform better.</p><p>Note: this Rockon uses the net=host option to allow for use of the dhcp functionality.",
+        "volume_add_support": false,
+            "ui": {
+                "slug": "admin"
+            },        
+        "website": "https://pi-hole.net/",
+        "version": "6.0"
+    }
 }


### PR DESCRIPTION
Fixes #427  .
 - Address breaking changes between pi-hole v5.x and v6.x
 - some text cleanup, convert to Unix LR and replace tabs with spaces.

- docker image: https://hub.docker.com/r/pihole/pihole
- is an official docker image available for this project?: yes


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
