### PR TITLE
Support alternate web UI for Transmission OpenVPN

### DIFF
--- a/transmission-with-openvpn.json
+++ b/transmission-with-openvpn.json
@@ -72,15 +72,20 @@
                         "label": "LOCAL_NETWORK",
                         "index": 6
                     },
+                    "TRANSMISSION_WEB_UI": {
+                        "description": "Alternative web UI to use; Use 'default' to leave the default Transmission UI, other options are: combustion, kettu, transmission-web-control, flood-for-transmission, shift or transmissionic.",
+                        "label": "TRANSMISSION_WEB_UI",
+                        "index": 7
+                    },
                     "PUID": {
                         "description": "Choose a User ID to run Transmission as",
                         "label": "User ID",
-                        "index": 7
+                        "index": 8
                     },
                     "PGID": {
                         "description": "Choose a Group ID to run Transmission as",
                         "label": "Group ID",
-                        "index": 8
+                        "index": 9
                     }
                 }
             }

--- a/transmission-with-openvpn.json
+++ b/transmission-with-openvpn.json
@@ -1,7 +1,7 @@
 {
     "Transmission - OpenVPN": {
-        "website": "https://hub.docker.com/r/haugene/transmission-openvpn/",
-        "version": "1.1",
+        "website": "https://haugene.github.io/docker-transmission-openvpn/",
+        "version": "1.2",
         "description": "Docker container running Transmission torrent client with WebUI while connecting to OpenVPN.<p>Based on a custom docker image: <a href='https://hub.docker.com/r/haugene/transmission-openvpn' target='_blank'>https://hub.docker.com/r/haugene/transmission-openvpn</a>, available for amd64 and arm64 architecture.</p>",
         "more_info": "<p>See the container's documentation for a list of included VPN provider profiles. If your provider isn't included, set it up as a custom provider, by putting the relevant files in the <code>Custom profile</code> share.</p>",
         "containers": {

--- a/transmission-with-openvpn.json
+++ b/transmission-with-openvpn.json
@@ -25,11 +25,11 @@
                 "volumes": {
                     "/data": {
                         "description": "Choose a Share where Transmission will save all of it's config and data files including your downloads. Eg: create a Share called transmission-data.",
-                        "label": "Data Storage"
+                        "label": "Data Storage [e.g. transmission-data]"
                     },
                     "/etc/openvpn/custom": {
                         "description": "Choose a Share where a set of custom OpenVPN profile files can be found. This can be an empty share if you use one of the included provider profiles.",
-                        "label": "OpenVPN config"
+                        "label": "OpenVPN config [e.g.: ovpn-config]"
                     }
                 },
                 "ports": {
@@ -68,12 +68,12 @@
                         "index": 5
                     },
                     "LOCAL_NETWORK": {
-                        "description": "IP range (in CIDR notation, e.g. 192.168.0.0/24) to consider 'local'; this range is added to the routing, so that the web UI can be used.",
+                        "description": "IP range(s) (in CIDR notation, e.g. 192.168.0.0/24) to consider 'local'; this range is added to the routing, so that the web UI can be used. Multiple networks can be specified, comma-separated.",
                         "label": "LOCAL_NETWORK",
                         "index": 6
                     },
                     "TRANSMISSION_WEB_UI": {
-                        "description": "Alternative web UI to use; Use 'default' to leave the default Transmission UI, other options are: combustion, kettu, transmission-web-control, flood-for-transmission, shift or transmissionic.",
+                        "description": "Alternative web UI to use; Use 'default' to leave the default Transmission UI, other options are (enter in lowercase): combustion, kettu, transmission-web-control, flood-for-transmission, shift or transmissionic.",
                         "label": "TRANSMISSION_WEB_UI",
                         "index": 7
                     },


### PR DESCRIPTION
Adds the `TRANSMISSION_WEB_UI` environment variable to config for the `Transmission - OpenVPN` image with documentation based on the [official image docs](https://haugene.github.io/docker-transmission-openvpn/config-options/#alternative_web_uis). 

Tried this with both `default` as the setting, as well as `combustion`, `flood-for-transmission` and `transmissionic` and it works fine. Users that re-install the image will just need to add `default` for the variable to continue with the existing experience.

I've also updated the rock-on version and website to link to the project website rather than the docker image itself.

Fixes #433 .

### General information on project
This pull request updates the existing `transmission-with-openvpn` rock-on. 


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
