### PR TITLE
Add Transmission based on newer LinuxServer image (#436)

### DIFF
--- a/root.json
+++ b/root.json
@@ -74,6 +74,7 @@
     "TeamSpeak3": "teamspeak3.json",
     "Transmission with OpenVPN": "transmission-with-openvpn.json",
     "Transmission": "transmission.json",
+    "Transmission LS": "transmission-ls.json",
     "Ubiquiti Unifi linuxserver.io": "unifi-linuxserver.json",
     "Unifi Controller": "unifi.json",
     "Vaultwarden": "vaultwarden.json",

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -1,0 +1,63 @@
+{
+    "Transmission LS": {
+        "description": "Open source bittorrent client powered by linuxserver.io",
+        "version": "2025.1",
+        "website": "https://transmissionbt.com/",
+        "containers": {
+            "transmission-ls": {
+                "image": "linuxserver/transmission",
+                "launch_order": 1,
+                "ports": {
+                    "51413": {
+                        "label": "Sharing port",
+                        "description": "Port used to share the file being downloaded. You may need to open it (protocol: tcp and udp) on your firewall. Suggested default: 51413.",
+                        "host_default": 51413
+                    },
+                    "9091": {
+                        "label": "WebUI port",
+                        "description": "Transmission WebUI port. Suggested default: 9091",
+                        "host_default": 9091,
+                        "protocol": "tcp",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Share used for storing configuration",
+                        "label": "Configuration"
+                    },
+                    "/downloads": {
+                        "description": "Share used for storing downloads",
+                        "label": "Downloads"
+                    },
+                    "/watch": {
+                        "description": "Share used for automatically starting a download when new torrent files are added",
+                        "label": "Watch"
+                    }
+                },
+                "environment": {
+                    "PUID": {
+                        "label": "UID",
+                        "description": "User ID to run Transmission as"
+                    },
+                    "PGID": {
+                        "label": "GUID",
+                        "description": "Group ID to run Transmission as"
+                    },
+                    "TZ": {
+                        "label": "TZ",
+                        "description": "Timezone. e.g. Etc/UTC"
+                    },
+                    "USER": {
+                        "label": "Web UI username",
+                        "description": "Username to authenticate on web ui"
+                    },
+                    "PASS": {
+                        "label": "Web UI password",
+                        "description": "Password to use on the web ui"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -1,6 +1,6 @@
 {
     "Transmission LS": {
-        "description": "Open source bittorrent client powered by linuxserver.io",
+        "description": "Open source bittorrent client powered by linuxserver.io.<p>Based on a custom docker image: <a href='https://hub.docker.com/r/linuxserver/transmission' target='_blank'>https://hub.docker.com/r/linuxserver/transmission</a>, available for amd64 and arm64 architecture.</p>",
         "version": "2025.1",
         "website": "https://transmissionbt.com/",
         "containers": {

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -32,7 +32,7 @@
                     },
                     "/watch": {
                         "description": "Share used for automatically starting a download when new torrent files are added",
-                        "label": "Watch"
+                        "label": "Watch [e.g.: transmission-watch]"
                     }
                 },
                 "environment": {

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -10,7 +10,7 @@
                 "ports": {
                     "51413": {
                         "label": "Sharing port",
-                        "description": "Port used to share the file being downloaded. You may need to open it (protocol: tcp and udp) on your firewall. Suggested default: 51413.",
+                        "description": "Port used to share the file being downloaded. You may need to open it (protocol: tcp and udp) on your firewall & router. Suggested default: 51413.",
                         "host_default": 51413
                     },
                     "9091": {

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -46,7 +46,7 @@
                     },
                     "USER": {
                         "label": "Web UI username",
-                        "description": "Username to authenticate on web ui"
+                        "description": "Username to authenticate on the web ui"
                     },
                     "PASS": {
                         "label": "Web UI password",

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -44,10 +44,6 @@
                         "label": "GUID",
                         "description": "Group ID to run Transmission as"
                     },
-                    "TZ": {
-                        "label": "TZ",
-                        "description": "Timezone. e.g. Etc/UTC"
-                    },
                     "USER": {
                         "label": "Web UI username",
                         "description": "Username to authenticate on web ui"

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -28,7 +28,7 @@
                     },
                     "/downloads": {
                         "description": "Share used for storing downloads",
-                        "label": "Downloads"
+                        "label": "Downloads [e.g.: transmission-downloads]"
                     },
                     "/watch": {
                         "description": "Share used for automatically starting a download when new torrent files are added",

--- a/transmission-ls.json
+++ b/transmission-ls.json
@@ -24,7 +24,7 @@
                 "volumes": {
                     "/config": {
                         "description": "Share used for storing configuration",
-                        "label": "Configuration"
+                        "label": "Configuration [e.g.: transmission-config]"
                     },
                     "/downloads": {
                         "description": "Share used for storing downloads",


### PR DESCRIPTION
Fixes #436 

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Transmission
- website: https://transmissionbt.com/
- description: We already have a Rockon definition for Transmission. However, it is rather outdated so I'm proposing an alternative based on the LinuxServer builds. I'm adding this as a separate Rockon definition because I'm unsure of the upgrade procedures for the existing one. I'm happy to edit the existing `transmission.json` instead if that's a safe route for existing installations.

### Information on docker image
- docker image: https://hub.docker.com/r/linuxserver/transmission
- is an official docker image available for this project?: No.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
