### PR TITLE
Bareos backup server #94

### DIFF
--- a/bareos-backup-server.json
+++ b/bareos-backup-server.json
@@ -1,0 +1,208 @@
+{
+  "Bareos Backup Server": {
+    "description": "Network-based '<strong>Ba</strong>ckup and <strong>Re</strong>covery <strong>O</strong>pen <strong>S</strong>ource software' for all major operating systems. Director/Catalog/Storage and director-local (catalog/config backups) File services. <a href='https://rockstor.com/docs/interface/docker-based-rock-ons/bareos-backup-server.html' target='_blank'>Rock-on guide</a>.<p><strong>Before install run: </strong><code>groupadd --system --gid 105 bareos</code> && <code>useradd --system --uid 105 --comment 'bareos' --home-dir /var/lib/bareos -g bareos -G disk,tape --shell /bin/false bareos</code><p><strong>After install requirement:</strong> click 'i' icon for instructions.<p>Based on <a href='https://codeberg.org/phillxnet/-/packages' target='_blank'>custom docker images</a> from the Rockstor maintainers, available for amd64 architecture only.</p>",
+    "more_info": "<h4>Required post-install configuration</h4><ol><li>System - Network - Add Connection (Name=BareosFdToStorage Type=docker).</li><li>This Rock-on's spanner icon - Networking - Rocknets - select BareosFdToStorage for bareos-fd & bareos-storage.</li><ol>",
+    "ui": {
+      "slug": "bareos-webui"
+    },
+    "version": "0.0.1",
+    "website": "https://www.bareos.org/",
+    "container_links": {
+      "bareos-dir": [
+        {
+          "name": "BareosDirToDB",
+          "source_container": "bareos-db"
+        },
+        {
+          "name": "BareosDirToStorage",
+          "source_container": "bareos-storage"
+        },
+        {
+          "name": "BareosDirToFd",
+          "source_container": "bareos-fd"
+        },
+        {
+          "name": "BareosDirToWebui",
+          "source_container": "bareos-webui"
+        }
+      ]
+    },
+    "containers": {
+      "bareos-db": {
+        "image": "postgres",
+        "tag": "16",
+        "launch_order": 1,
+        "volumes": {
+          "/var/lib/postgresql/data": {
+            "description": "'Catalog' storage (Postgres DB).",
+            "label": "'Catalog' data [e.g. bareos-catalog]"
+          }
+        },
+        "environment": {
+          "POSTGRES_PASSWORD": {
+            "description": "Set password for `postgres` super-user.",
+            "label": "'postgres' super-user password"
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "POSTGRES_INITDB_ARGS=--encoding=SQL_ASCII"
+          ]
+        ]
+      },
+      "bareos-dir": {
+        "image": "codeberg.org/phillxnet/bareos-director",
+        "tag": "latest",
+        "launch_order": 2,
+        "uid": 105,
+        "volumes": {
+          "/etc/bareos": {
+            "description": "'Director' configuration (bareos:bareos).",
+            "label": "'Director' config [e.g. bareos-dir-config]"
+          },
+          "/var/lib/bareos": {
+            "description": "'Director' data/state (bareos:bareos).",
+            "label": "'Director' data [e.g. bareos-dir-data]"
+          }
+        },
+        "ports": {
+          "9101": {
+            "description": "'Director' communications port.",
+            "host_default": 9101,
+            "label": "'Director' port [must be 9101]",
+            "protocol": "tcp",
+            "ui": false
+          }
+        },
+        "environment": {
+          "DB_ADMIN_PASSWORD": {
+            "description": "Re-enter `postgres` super-user password.",
+            "label": "Re-enter 'postgres' super-user password"
+          },
+          "DB_PASSWORD": {
+            "description": "Set password for the `bareos` DB user.",
+            "label": "Catalog's `bareos` user password"
+          },
+          "BAREOS_SD_PASSWORD": {
+            "description": "Set 'Storage' service password.",
+            "label": "'Storage' password"
+          },
+          "BAREOS_FD_PASSWORD": {
+            "description": "Set Director's local 'File'/Client service (bareos-fd) password.",
+            "label": "Director's local 'File' password"
+          },
+          "BAREOS_WEBUI_PASSWORD": {
+            "description": "Set Bareos WebUI 'admin' user password.",
+            "label": "WebUI 'admin' user's password"
+          },
+          "SMTP_HOST": {
+            "description": "Set email relay hostname or IP - example uses Rockstor's Email Alerts.",
+            "label": "SMTP relay host [e.g. Rockstor's IP]"
+          },
+          "SENDER_EMAIL": {
+            "description": "'From:' email address - sending Bareos notifications.",
+            "label": "Sender email [see Email Alerts]"
+          },
+          "RECEIVER_EMAIL": {
+            "description": "'To:' email address - receives Bareos notifications.",
+            "label": "Receiver email [see Email Alerts]"
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "DB_INIT=true"
+          ],
+          [
+            "-e",
+            "DB_NAME=bareos"
+          ],
+          [
+            "-e",
+            "DB_USER=bareos"
+          ],
+          [
+            "-e",
+            "DB_ADMIN_USER=postgres"
+          ],
+          [
+            "-e",
+            "DB_HOST=bareos-db"
+          ],
+          [
+            "-e",
+            "DB_PORT=5432"
+          ],
+          [
+            "-e",
+            "BAREOS_SD_HOST=bareos-storage"
+          ],
+          [
+            "-e",
+            "BAREOS_FD_HOST=bareos-fd"
+          ]
+        ]
+      },
+      "bareos-storage": {
+        "image": "codeberg.org/phillxnet/bareos-storage",
+        "tag": "latest",
+        "launch_order": 3,
+        "uid": 105,
+        "volumes": {
+          "/var/lib/bareos/storage": {
+            "description": "'Storage' for all backups (bareos:bareos).",
+            "label": "Backups data [e.g. bareos-backups]"
+          }
+        },
+        "ports": {
+          "9103": {
+            "description": "'Storage' communications port.",
+            "host_default": 9103,
+            "label": "'Storage' port [must be 9103]",
+            "protocol": "tcp",
+            "ui": false
+          }
+        },
+        "opts": [
+          [
+            "--volumes-from",
+            "bareos-dir"
+          ]
+        ]
+      },
+      "bareos-fd": {
+        "image": "codeberg.org/phillxnet/bareos-file",
+        "tag": "latest",
+        "launch_order": 4,
+        "uid": 105,
+        "opts": [
+          [
+            "--volumes-from",
+            "bareos-dir"
+          ]
+        ]
+      },
+      "bareos-webui": {
+        "image": "codeberg.org/phillxnet/bareos-webui",
+        "tag": "latest",
+        "launch_order": 5,
+        "volumes": {
+          "/etc/bareos-webui": {
+            "description": "'WebUI' configuration.",
+            "label": "'WebUI' config [e.g. bareos-webui]"
+          }
+        },
+        "ports": {
+          "80": {
+            "description": "Bareos Web Interface.",
+            "host_default": 9100,
+            "label": "WebUI port [e.g. 9100]",
+            "protocol": "tcp",
+            "ui": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/root.json
+++ b/root.json
@@ -2,6 +2,7 @@
     "2FAuth": "2FAuth.json",
     "AdGuard Home": "adguard.json",
     "Airsonic Advanced": "airsonic-advanced.json",
+    "Bareos Backup Server": "bareos-backup-server.json",
     "Booksonic": "booksonic.json",
     "Calibre": "calibre.json",
     "Collabora Online": "collabora-online.json",


### PR DESCRIPTION
Fixes #94 

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Bareos
- website: https://www.bareos.com/
- description: see below header:

### Description
Network-based 'Backup and Recovery Open Source software' for all major operating systems. Director/Catalog/Storage and director-local (catalog/config backups) File services. Defaults to File based storage (a Share), and is intended as the Server-side to Client machines/DB's etc in need of backup services (Bareos Client software required).

#### Notes:
- Explicitly invoke `-u 105` during container run
- As a server-set, with ordered install, we can inherit (via the shared config arrangement) all intra Bareos service passwords. File and Storage containers are now able to self-config when uses in this intended AIO setup. This is akin to the rpms default behaviour of reading each-others config in order to auto-setup the initial server set.
-The SMTP_HOST environment variable are intended to enable access to Rockstor as an SMTP relay; enabling the default Bareos email notification with minimum setup.
- Docker network naming in Pascal Case. Exception is DB but this is a common Data Base abbreviation. We also drop File as "Fd" more closely matches the relevant container name.
- Contains link to a proposed Rock-on guide (https://github.com/rockstor/rockstor-doc/pull/546)

### Information on docker image/s
Multi-container Bareos server set Rock-on containing:
- Director Service (overall controller): https://codeberg.org/phillxnet/-/packages/container/bareos-director/latest
- Catalog Service (Postgres DB for Director): Official Postgres 16 image.
- Storage Service (Back-end Storage for Director and File (client) services): https://codeberg.org/phillxnet/-/packages/container/bareos-storage/latest
- Director-local File (client) Service (for Catalog backup capability): https://codeberg.org/phillxnet/-/packages/container/bareos-file/latest
- Web-UI Service (Director Web-UI interface): https://codeberg.org/phillxnet/-/packages/container/bareos-webui/latest

- is an official docker image available for this project?: No.


### Checklist
- [x] Passes [JSONlint](https://jsonlint.com) validation
- [x] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [x] `"description"` object lists and links to the docker image used
- [x] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x] `"website"` object links to project's main website
