### PR TITLE
New Rockon for forgejo [#449]

### DIFF
--- a/forgejo.json
+++ b/forgejo.json
@@ -62,7 +62,7 @@
           "22": {
             "description": "forgejo ssh port.",
             "host_default": 222,
-            "label": "ssh port [default: 222]",
+            "label": "SSH port [e.g. 222]",
             "protocol": "tcp",
             "ui": false
           }

--- a/forgejo.json
+++ b/forgejo.json
@@ -22,7 +22,7 @@
         "launch_order": 1,
         "volumes": {
           "/var/lib/postgresql/data": {
-            "description": "Forgejo database location. E.g.: create a Share called forgejo-d for this purpose alone.",
+            "description": "Forgejo database location. E.g.: create a Share called forgejo-db for this purpose alone.",
             "label": "Forgejo db [e.g. forgejo-db]"
           }
         },

--- a/forgejo.json
+++ b/forgejo.json
@@ -1,6 +1,6 @@
 {
-  "forgejo": {
-    "description": "forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.<p><p>Based on the official docker image: <a href='https://codeberg.org/forgejo/-/packages/container/forgejo/12' target=_blank>https://codeberg.org/forgejo/-/packages/container/forgejo/12</a>, available for amd64 and arm64 architecture.</p>",
+  "Forgejo": {
+    "description": "Forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.<p><p>Based on the official docker image: <a href='https://codeberg.org/forgejo/-/packages/container/forgejo/12' target=_blank>https://codeberg.org/forgejo/-/packages/container/forgejo/12</a>, available for amd64 and arm64 architecture.</p>",
     "more_info": "",
     "ui": {
       "slug": ""
@@ -18,12 +18,12 @@
     "containers": {
       "forgejo-db": {
         "image": "postgres",
-        "tag": "latest",
+        "tag": "16",
         "launch_order": 1,
         "volumes": {
           "/var/lib/postgresql/data": {
-            "description": "forgejo database location. E.g.: create a Share called forgejo-d for this purpose alone.",
-            "label": "forgejo db [e.g. forgejo-db]"
+            "description": "Forgejo database location. E.g.: create a Share called forgejo-d for this purpose alone.",
+            "label": "Forgejo db [e.g. forgejo-db]"
           }
         },
         "opts": [
@@ -48,19 +48,19 @@
         "volumes": {
           "/data": {
             "description": "Choose a Share for forgejo data. E.g.: create a Share called forgejo-data for this purpose alone.",
-            "label": "forgejo data [e.g. forgejo-data]"
+            "label": "Forgejo data [e.g. forgejo-data]"
           }
         },
         "ports": {
           "3000": {
-            "description": "forgejo WebUI port.",
+            "description": "Forgejo WebUI port.",
             "host_default": 3000,
-            "label": "WebUI port [default 3000]",
+            "label": "WebUI port [e.g. 3000]",
             "protocol": "tcp",
             "ui": true
           },
           "22": {
-            "description": "forgejo ssh port.",
+            "description": "Forgejo SSH port.",
             "host_default": 222,
             "label": "SSH port [e.g. 222]",
             "protocol": "tcp",
@@ -69,13 +69,13 @@
         },
         "environment": {
           "USER_UID": {
-            "description": "Enter a valid UID to run forgejo with. It must have full permissions to the share mapped in the previous step.",
-            "label": "UID [e.g.: 1000]",
+            "description": "Enter a valid UID to run Forgejo with. It must have full permissions to the share mapped in the previous step.",
+            "label": "UID [e.g. 1000]",
             "index": 1
           },
           "USER_GID": {
-            "description": "Enter a valid GID to run forgejo with. It must have full permissions to the share mapped in the previous step.",
-            "label": "GID [e.g.: 1000]",
+            "description": "Enter a valid GID to run Forgejo with. It must have full permissions to the share mapped in the previous step.",
+            "label": "GID [e.g. 1000]",
             "index": 2
           }
         },

--- a/forgejo.json
+++ b/forgejo.json
@@ -1,0 +1,107 @@
+{
+  "forgejo": {
+    "description": "forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance, it just does the job.<p><p>Based on the official docker image: <a href='https://codeberg.org/forgejo/-/packages/container/forgejo/12' target=_blank>https://codeberg.org/forgejo/-/packages/container/forgejo/12</a>, available for amd64 and arm64 architecture.</p>",
+    "more_info": "",
+    "ui": {
+      "slug": ""
+    },
+    "version": "0.5.0",
+    "website": "https://forgejo.org/",
+    "container_links": {
+      "forgejo": [
+        {
+          "name": "forgejo",
+          "source_container": "forgejo-db"
+        }
+      ]
+    },
+    "containers": {
+      "forgejo-db": {
+        "image": "postgres",
+        "tag": "latest",
+        "launch_order": 1,
+        "volumes": {
+          "/var/lib/postgresql/data": {
+            "description": "forgejo database location. E.g.: create a Share called forgejo-d for this purpose alone.",
+            "label": "forgejo db [e.g. forgejo-db]"
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "POSTGRES_USER=forgejo"
+          ],
+          [
+            "-e",
+            "POSTGRES_PASSWORD=forgejo"
+          ],
+          [
+            "-e",
+            "POSTGRES_DB=forgejo"
+          ]
+        ]
+      },
+      "forgejo": {
+        "image": "codeberg.org/forgejo/forgejo",
+        "tag": "12",
+        "launch_order": 2,
+        "volumes": {
+          "/data": {
+            "description": "Choose a Share for forgejo data. E.g.: create a Share called forgejo-data for this purpose alone.",
+            "label": "forgejo data [e.g. forgejo-data]"
+          }
+        },
+        "ports": {
+          "3000": {
+            "description": "forgejo WebUI port.",
+            "host_default": 3000,
+            "label": "WebUI port [default 3000]",
+            "protocol": "tcp",
+            "ui": true
+          },
+          "22": {
+            "description": "forgejo ssh port.",
+            "host_default": 222,
+            "label": "ssh port [default: 222]",
+            "protocol": "tcp",
+            "ui": false
+          }
+        },
+        "environment": {
+          "USER_UID": {
+            "description": "Enter a valid UID to run forgejo with. It must have full permissions to the share mapped in the previous step.",
+            "label": "UID [e.g.: 1000]",
+            "index": 1
+          },
+          "USER_GID": {
+            "description": "Enter a valid GID to run forgejo with. It must have full permissions to the share mapped in the previous step.",
+            "label": "GID [e.g.: 1000]",
+            "index": 2
+          }
+        },
+        "opts": [
+          [
+            "-e",
+            "FORGEJO__database__DB_TYPE=postgres"
+          ],
+          [
+            "-e",
+            "FORGEJO__database__HOST=forgejo-db:5432"
+          ],
+          [
+            "-e",
+            "FORGEJO__database__NAME=forgejo"
+          ],
+          [
+            "-e",
+            "FORGEJO__database__USER=forgejo"
+          ],
+          [
+            "-e",
+            "FORGEJO__database__PASSWD=forgejo"
+          ]
+        ]
+      }
+    }
+  }
+}

--- a/forgejo.json
+++ b/forgejo.json
@@ -10,7 +10,7 @@
     "container_links": {
       "forgejo": [
         {
-          "name": "forgejo",
+          "name": "ForgejoToDB",
           "source_container": "forgejo-db"
         }
       ]

--- a/root.json
+++ b/root.json
@@ -17,6 +17,7 @@
     "FileBot Node": "filebot-node.json",
     "Filebrowser": "filebrowser.json",
     "Folding@home Linuxserver.io": "foldingathome-linuxserver.json",
+    "forgejo": "forgejo.json",
     "Forgejo Runner": "forgejo-runner.json",
     "FreshRSS": "FreshRSS.json",
     "Ghost": "ghost.json",

--- a/root.json
+++ b/root.json
@@ -18,7 +18,7 @@
     "FileBot Node": "filebot-node.json",
     "Filebrowser": "filebrowser.json",
     "Folding@home Linuxserver.io": "foldingathome-linuxserver.json",
-    "forgejo": "forgejo.json",
+    "Forgejo": "forgejo.json",
     "Forgejo Runner": "forgejo-runner.json",
     "FreshRSS": "FreshRSS.json",
     "Ghost": "ghost.json",


### PR DESCRIPTION
Fixes #449.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: forgejo
- website: https://forgejo.org/
- description:  forgejo is a self-hosted lightweight software forge. Easy to install and low maintenance

### Information on docker image
- docker image: https://codeberg.org/forgejo/-/packages/container/forgejo/12 as well as latest postgres db from docker hub
- is an official docker image available for this project?: yes


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website

---

[EDIT phillxnet]

- Doc reference for docker implementation: https://forgejo.org/docs/latest/admin/installation/docker/