### PR TITLE
Introduce audiobookshelf Rockon (#454)

### DIFF
--- a/audiobookshelf.json
+++ b/audiobookshelf.json
@@ -1,0 +1,44 @@
+{
+    "audiobookshelf": {
+        "description": "Audiobookshelf is an open-source self-hosted media server for your audiobooks and podcasts.<p>Based the official docker image: <a href='https://hub.docker.com/r/advplyr/audiobookshelf' target='_blank'>https://hub.docker.com/r/advplyr/audiobookshelf</a>, available for amd64 and arm64 architecture.</p>",
+        "more_info": "After installation more media shares can be added.",
+        "ui": {
+            "slug": ""
+        },
+        "volume_add_support": true,
+        "website": "https://www.audiobookshelf.org/",
+        "version": "1.0",
+        "containers": {
+            "audiobookshelf": {
+                "image": "advplyr/audiobookshelf",
+                "launch_order": 1,
+                "ports": {
+                    "80": {
+                        "description": "WebUI port. Suggested default: 13378",
+                        "host_default": 13378,
+                        "label": "WebUI port",
+                        "ui": true
+                    }
+                },
+                "volumes": {
+                    "/config": {
+                        "description": "Choose a Share for the configuration data. It will contain the database (users/books/libraries/settings).",
+                        "label": "Config Storage [e.g.: audiobookshelf-config]"
+                    },
+                    "/audiobooks": {
+                        "description": "Choose a Share for audiobooks.",
+                        "label": "Audiobooks Storage [e.g.: audiobookshelf-books]"
+                    },
+                    "/podcasts": {
+                        "description": "Choose a Share for podcasts.",
+                        "label": "Podcasts Storage [e.g.: audiobookshelf-podcasts]"
+                    },
+                    "/metadata": {
+                        "description": "Choose a Share for metadata (cache/streams/covers/downloads/backups/logs).",
+                        "label": "Metadata Storage [e.g.: audiobookshelf-metadata]"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/root.json
+++ b/root.json
@@ -2,6 +2,7 @@
     "2FAuth": "2FAuth.json",
     "AdGuard Home": "adguard.json",
     "Airsonic Advanced": "airsonic-advanced.json",
+    "audiobookshelf": "audiobookshelf.json",
     "Bareos Backup Server": "bareos-backup-server.json",
     "Booksonic": "booksonic.json",
     "Calibre": "calibre.json",


### PR DESCRIPTION
Fixes #454 .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: audiobookshelf
- website: https://www.audiobookshelf.org
- description: Audiobookshelf is an open-source self-hosted media server for your audiobooks and podcasts.

### Information on docker image
- docker image: https://hub.docker.com/r/advplyr/audiobookshelf (there is also a github image available)
- is an official docker image available for this project?:  yes


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
