### PR TITLE
Kanecko immich patch 1

### DIFF
--- a/immich.json
+++ b/immich.json
@@ -1,0 +1,123 @@
+{
+  "Immich": {
+    "description": "Immich is a high-performance self-hosted photo and video backup solution with official mobile apps and 3rd-party smart TV apps. <p>Includes multiple custom docker images: Immich server, Immich machine-learning server, Redis and Postgres.</p> <p>Based on the official Docker Compose <a href='https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml' target='_blank'>configuration file</a>, available for amd64 and arm64 architecture.</p>",
+    "version": "1.0.0",
+    "website": "https://immich.app",
+    "icon": "https://immich.app/img/logomark-light.svg",
+    "volume_add_support": true,
+    "container_links": {
+      "immich-server": [
+        {
+          "name": "ImmichServerToRedis",
+          "source_container": "redis"
+        },
+        {
+          "name": "ImmichServerToDatabase",
+          "source_container": "database"
+        }
+      ]
+    },    
+    "containers": {
+      "database": {
+        "image": "ghcr.io/immich-app/postgres",
+        "tag": "14-vectorchord0.4.3-pgvectors0.2.0",
+        "launch_order": 1,
+        "volumes": {
+          "/var/lib/postgresql/data": {
+            "description": "Choose a Database Share for Immich.",
+            "label": "Database Share [e.g. immich-db]"
+          }
+        },
+        "opts": [
+          [ "--shm-size", "128mb" ],
+          [ "--restart", "always" ],
+          [ "-e", "POSTGRES_USER=postgres" ],
+          [ "-e", "POSTGRES_PASSWORD=postgres" ],
+          [ "-e", "POSTGRES_DB=immich" ],
+          [ "-e", "POSTGRES_INITDB_ARGS=--data-checksums" ]
+        ]
+      },
+      "redis": {
+        "image": "valkey/valkey",
+        "tag": "8-bookworm",
+        "launch_order": 2,
+        "opts": [
+          [ "--restart", "always" ]
+        ]
+      },
+      "immich-machine-learning": {
+        "image": "ghcr.io/immich-app/immich-machine-learning",
+        "tag": "release",
+        "launch_order": 3,
+        "environment": {
+          "UPLOAD_LOCATION": {
+              "description": "The location where your uploaded photos/videos are stored. Has to be the same as Library Share.",
+              "label": "Upload location [e.g. /mnt2/immich-library]"
+          },
+          "DB_DATA_LOCATION": {
+              "description": "The location where your database files are stored. Has to be the same as Database Share.",
+              "label": "Database location [e.g. /mnt2/immich-db]"
+          }
+        },
+        "volumes": {
+          "/cache": {
+            "description": "Choose a Cache Share for the machine-learning models.",
+            "label": "Cache Share [e.g. immich-cache]"
+          }
+        },
+        "opts": [
+          [ "--restart", "always" ],
+          [ "-e", "DB_USERNAME=postgres" ],
+          [ "-e", "DB_PASSWORD=postgres" ],
+          [ "-e", "DB_DATABASE_NAME=immich" ]          
+        ]
+      },
+      "immich-server": {
+        "image": "ghcr.io/immich-app/immich-server",
+        "tag": "release",
+        "launch_order": 4,
+        "ports": {
+          "2283": {
+            "description": "Immich API/Server port.",
+            "label": "Web interface port [e.g. 2283]",
+            "host_default": 2283,
+            "protocol": "tcp",
+            "ui": true
+          }
+        },
+        "environment": {
+          "UPLOAD_LOCATION": {
+              "description": "The location where your uploaded photos/videos are stored. Has to be the same as Library Share.",
+              "label": "Upload location [e.g. /mnt2/immich-library]",
+              "index": 1
+          },
+          "DB_DATA_LOCATION": {
+              "description": "The location where your database files are stored. Has to be the same as Database Share.",
+              "label": "Database location [e.g. /mnt2/immich-db]",
+              "index": 2
+          },
+          "IMMICH_LOG_LEVEL": {
+              "description": "Log level (verbose, debug, log, warn, error).",
+              "label": "Log level [e.g. log]",
+              "index": 3
+          },
+          "IMMICH_IGNORE_MOUNT_CHECK_ERRORS": {
+              "description": "When Immich starts, it checks if it can read and write to the storage volume mounts. Set to true to disable checks.",
+              "label": "Ignore error checks [e.g. false]",
+              "index": 4
+          }
+        },
+        "volumes": {
+          "/data": {
+            "description": "Choose a Library Share, where Immich stores uploaded photos/videos.",
+            "label": "Library Share [e.g. immich-library]"
+          }
+        },
+        "opts": [
+          [ "-v", "/etc/localtime:/etc/localtime:ro" ],
+          [ "--restart", "always" ]
+        ]
+      }
+    }
+  }
+}

--- a/root.json
+++ b/root.json
@@ -31,6 +31,7 @@
     "Headphones": "headphones.json",
     "Home Assistant by Linuxserver.io": "home-assistant-linuxserver.json",
     "HTTP to HTTPS redirect": "redirect-http-to-https.json",
+    "Immich": "immich.json",
     "IT Tools": "it-tools.json",
     "Jackett": "Jackett.json",
     "JDownloader 2": "Jdownloader2.json",


### PR DESCRIPTION
> To ease and accelerate the PR submission, please use the template below to provide all requested information.
> You can find guidelines on which docker image to use in the [Rockstor's documentation](http://rockstor.com/docs/contribute_rockons.html#which-docker-image-should-i-use), 
> as well as examples of proper formatting in other rock-ons ([here](https://github.com/rockstor/rockon-registry/blob/master/teamspeak3.json)
> and [here](https://github.com/rockstor/rockon-registry/blob/master/nextcloud-official.json))



Fixes #477 .

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Immich
- website: https://immich.app/
- description: Self-hosted photo and video management solution. It is a multi-container rockon with a single exposed web-ui port and two internal docker networks. 

### Information on docker image
- docker images:  ghcr.io/immich-app/immich-server:release, ghcr.io/immich-app/immich-machine-learning:release, docker.io/valkey/valkey:8-bookworm, ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
- is an official docker image available for this project?: yes


### Checklist
- [ x] Passes [JSONlint](https://jsonlint.com) validation
- [x ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [ ] `"description"` object lists and links to the docker image used
- [ ] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [x ] `"website"` object links to project's main website

### Additional infos:
 - endusers will probably want to expose their existing photo/video share to immich. This will have to be done via the post-installation "Add Volume" button. How do I document this for the enduser?
 - additionally, it would be beneficial, if any existing shares would be exposed only with Read-Only access (i.e [ "-v", "/mnt2/myphotos:/mnt2/myphotos**:ro**" ]). I don't suppose the webUI allows that?
 - It installs, but haven't had the time to test it yet! To test: web app, mobile app, tv app, mobile auto-backup, existing shares, ML functionality (smart search?)
