### PR TITLE
Resolve quoted 'integer' value instances #479

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ A typical container object has the following structure
 ```
 {
   "image": "<docker image. eg: linuxserver/plex>",
-  (optional)"tag": "tag of the docker image, if any. "latest" is used by default.>",
-  "launch_order": "1 or above. If there are multiple containers and they must be started in order, specify here.>",
+  (optional)"tag": "<tag of the docker image, if any. "latest" is used by default.>",
+  "launch_order": "<integer: 1 or above. If there are multiple containers and they must be started in order, specify here.>",
   (optional) "uid": <UID: user id that is going to be used to execute a command or entrypoint inside the container. See below.>, 
   (optional)"ports": {
     "<container side port number1>": <port object represending a port mapping between host and container. See below.>,
@@ -147,7 +147,7 @@ This optional object allows the mapping of Rockstor shares onto volume paths exp
 {
   "description": "<A detailed description. E.g. 'This is where all incoming syncthing data will be stored'>",
   "label": "<A short label, e.g. 'Data Storage [e.g. syncthing-storage]'>",
-  (optional)"min_size": <integer: suggested minimum size of the Share, in KB>
+  (optional)"min_size": <integer: suggested minimum size of the Share, in Bytes>
 }
 ```
 

--- a/filebot-node.json
+++ b/filebot-node.json
@@ -13,7 +13,7 @@
             "filebot": {
                 "image": "rednoah/filebot",
                 "tag": "node",
-                "launch_order": "1",
+                "launch_order": 1,
                 "ports": {
                     "5452": {
                         "description": "This is for the FileBot Node Client WebUI.",

--- a/ghost.json
+++ b/ghost.json
@@ -17,7 +17,7 @@
                     "/var/lib/ghost/content": {
                         "description": "Choose a share for your blog data.",
                         "label": "Blog Storage",
-                        "min_size": "1073741824"
+                        "min_size": 1073741824
                     }
                 }
             }

--- a/pocketmine.json
+++ b/pocketmine.json
@@ -16,7 +16,7 @@
                     "/data": {
                         "description": "Choose a Share for the configuration and persistent data.",
                         "label": "Config Storage (may need to be 777)",
-                        "min_size": "1073741824"
+                        "min_size": 1073741824
                     }
                 },
 		"opts": [

--- a/zabbix-xxl.json
+++ b/zabbix-xxl.json
@@ -25,7 +25,7 @@
                     "/var/lib/mysql": {
                         "description": "Choose a Share for Zabbix Database. (create a share called zabbix-db for this purpose)",
                         "label": "Zabbix Database",
-                        "min_size": "1073741824"
+                        "min_size": 1073741824
                     }
                 }
             },
@@ -36,7 +36,7 @@
                     "/backups": {
                         "description": "Choose a Share for Zabbix Backups. (create a share called zabbix-backups for this purpose)",
                         "label": "Zabbix Backups",
-                        "min_size": "1073741824"
+                        "min_size": 1073741824
                     }
                 },
                 "opts": [


### PR DESCRIPTION
Fixes #479

### Proposal
Unquote a number of intentionally integer values,
that were inadvertently entered as strings (quoted).

Update README.md regarding:
- a missing integer specification.
- Bytes for min_size rather than KB.
- Trivial formatting char addition.

### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation

---

Associated with on-going devleopment within the following repo: https://github.com/rockstor/rockon-validator

Specivially: https://github.com/rockstor/rockon-validator/issues/45
