### PR TITLE
Update Watchtower Official details and configuration

### DIFF
--- a/watchtower_official.json
+++ b/watchtower_official.json
@@ -1,42 +1,42 @@
 {
-	"Watchtower Official": {
-		"website": "https://containrrr.github.io/watchtower",
-		"version": "1.2",
-		"description": "A process for automating Docker container base image updates.<p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>CRON Generator</a></p><p>Based on the official docker image: <a href='https://hub.docker.com/r/containrrr/watchtower' target=_blank'> https://hub.docker.com/r/containrrr/watchtower</a>, available for amd64 and arm64 architecture. </p>",
-		"more_info": "<h4>Tips for CRON expressions</h4><p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>Freeformatter.com: CRON Generator</a></p> <h4>Watchtower Container Labels</h4><p>In order to add labels to the containers to be watched by the Watchtower application (including Watchtower itself, if so desired), stop the corresponding container, and select the 'Add Label' under settings. The new label name must contain the entire flag setting, and should be entered like this:</p><p><code>com.centurylinklabs.watchtower.enable=true</code> if the value for <code>WATCHTOWER_LABEL_ENABLE</code> is set to true or</p><p><code>com.centurylinklabs.watchtower.enable=false</code> if the value is set to false.</p><p>More information can be found here: <a href='https://containrrr.dev/watchtower/container-selection/' target=_blank>Watchtower Container Selection</a></p>",
-		"containers": {
-			"watchtower_official": {
-				"image": "containrrr/watchtower",
-				"tag": "latest",
-				"launch_order": 1,
-				"opts": [
-					[
-						"-v",
-						"/var/run/docker.sock:/var/run/docker.sock"
-					],
-					[
-						"--privileged",
-						""
+  "Watchtower Official": {
+    "website": "https://watchtower.nickfedor.com",
+    "version": "1.3",
+    "description": "A process for automating Docker container base image updates.<p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>CRON Generator</a></p><p>Based on the <a href='https://hub.docker.com/r/nickfedor/watchtower' target=_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
+    "more_info": "<h4>Tips for CRON expressions</h4><p>Watchtower uses CRON expressions to schedule update checks (only 6 fields are considered, so no year recurrence). For a handy CRON expression generator see here: <a href='https://www.freeformatter.com/cron-expression-generator-quartz.html#crongenerator' target='_blank'>Freeformatter.com: CRON Generator</a></p> <h4>Watchtower Container Labels</h4><p>In order to add labels to the containers to be watched by the Watchtower application (including Watchtower itself, if so desired), stop the corresponding container, and select the 'Add Label' under settings. The new label name must contain the entire flag setting, and should be entered like this:</p><p><code>com.centurylinklabs.watchtower.enable=true</code> if the value for <code>WATCHTOWER_LABEL_ENABLE</code> is set to true or</p><p><code>com.centurylinklabs.watchtower.enable=false</code> if the value is set to false.</p><p>More information can be found under the Container Selection section of the <a href='https://watchtower.nickfedor.com' target=_blank>Watchtower documentation</a></p>",
+    "containers": {
+      "watchtower_official": {
+        "image": "nickfedor/watchtower",
+        "tag": "latest",
+        "launch_order": 1,
+        "opts": [
+          [
+            "-v",
+            "/var/run/docker.sock:/var/run/docker.sock"
+          ],
+          [
+            "--privileged",
+            ""
                     ]
-				],
-				"environment": {
-					"WATCHTOWER_LABEL_ENABLE": {
-						"description": "If this flag is set to 'true', containers with a specific label string (see the 'More info' icon) will be updated (you can use the 'Add label' functionality to add labels after installing Rockons). If the flag is set to 'false', containers with the label will be excluded. It is recommended to set it to true during installation. Note: Only running containers will be considered.",
-						"label": "Filter by label enable",
-						"index": 1
-					},
-					"WATCHTOWER_SCHEDULE": {
-						"description": "CRON expression (6 fields) defining when and how often to check for new images. E.g.: to have Watchtower check every month on the 1st, at noon (include spaces in between values): 0 0 12 1 * ?",
-						"label": "Scheduling (CRON format)",
-						"index": 2
+        ],
+        "environment": {
+          "WATCHTOWER_LABEL_ENABLE": {
+            "description": "If this flag is set to 'true', containers with a specific label string (see the 'More info' icon) will be updated (you can use the 'Add label' functionality to add labels after installing Rockons). If the flag is set to 'false', containers with the label will be excluded. It is recommended to set it to true during installation. Note: Only running containers will be considered.",
+            "label": "Filter by label enable [e.g. true]",
+            "index": 1
+          },
+          "WATCHTOWER_SCHEDULE": {
+            "description": "CRON expression (6 fields) defining when and how often to check for new images. The example expression will have Watchtower check every month on the 1st day at noon.",
+            "label": "Scheduling [e.g. 0 0 12 1 * ?]",
+            "index": 2
                     },
                     "WATCHTOWER_CLEANUP": {
-						"description": "Removes old Images after updating. Setting the parameter to 'true' will remove old images, setting it to 'false' will keep old images untouched after the update. Recommended value is 'true' to avoid accumulation of old images, especially on regularly updated containers.",
-						"label": "Remove old images after update",
-						"index": 3
+            "description": "Removes old Images after updating. Setting the parameter to 'true' will remove old images, setting it to 'false' will keep old images untouched after the update. Recommended value is 'true' to avoid accumulation of old images, especially on regularly updated containers.",
+            "label": "Remove old images after update [e.g. true]",
+            "index": 3
                     }
-				}
-			}
-		}
-	}
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #485  .

Updating to the presumably new official docker image/repo, as the original Watchtower repo has not been updated in ~2 years.

### Changes to existing JSON file:
- Updated Watchtower Official information including website, version, and description.
- Modified container image and environment variables labels for configuration.
- Correct json indentation to two spaces per indent.

### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
