### PR TITLE
Replace minio docker image (#481)

### DIFF
--- a/minio.json
+++ b/minio.json
@@ -17,7 +17,7 @@
         },
         "volumes": {
           "/data": {
-            "description": "Choose a share for MinIO object storage",
+            "description": "Choose a share for MinIO object storage that can be accessed by the Rock-on's user [e.g. create a group clngroup with GID=102 and create a user clnstrt with UID=180802 assigned to the previously created group].",
             "label": "Object Storage [e.g. minio-obj-store]"
           }
         },


### PR DESCRIPTION
Fixes #481 .

Unfortunately, the MinIO project is not providing an updated official container anymore. This PR proposes the use of a custom docker image that is regularly built from source on top of a security hardened base image. This image change is a drop-in, as the same parameters are used for the custom docker image.

### Information on docker image
- docker image: https://hub.docker.com/r/cleanstart/minio/
- is an official docker image available for this project?: yes, but not updated anymore (see above)


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
