### PR TITLE
Add new gid element to Jenkins #500

### DIFF
--- a/jenkins.json
+++ b/jenkins.json
@@ -1,42 +1,39 @@
 {
-    "JenkinsCI": {
-        "description": "Jenkins is an open source automation server. Reliably build, test, and deploy software.<p>Based on the official docker image: <a href='https://hub.docker.com/r/jenkins/jenkins' target='_blank'>https://hub.docker.com/r/jenkins/jenkins</a>, available for amd64 and arm64 architecture. Rockstor V5.5.0 or later.</p>",
-        "more_info": "Initial Web-UI visit gives location of admin password within the chosen share.<p>Click spanner icon for share name and associated mapping.",
-        "ui": {
-            "slug": ""
+  "JenkinsCI": {
+    "description": "Jenkins is an open source automation server. Reliably build, test, and deploy software.<p>Based on the official docker image: <a href='https://hub.docker.com/r/jenkins/jenkins' target='_blank'>https://hub.docker.com/r/jenkins/jenkins</a>, available for amd64 and arm64 architecture. Rockstor V5.5.0 or later.</p>",
+    "version": "2.528.3",
+    "website": "https://jenkins.io/",
+    "icon": "http://ftp-nyc.osuosl.org/pub/jenkins/art/jenkins-logo/128x128/logo.png",
+    "more_info": "Initial Web-UI visit gives location of admin password within the chosen share.<p>Click spanner icon for share name and associated mapping.",
+    "containers": {
+      "jenkins": {
+        "image": "jenkins/jenkins",
+        "tag": "lts",
+        "launch_order": 1,
+        "uid": -1,
+        "gid": -1,
+        "ports": {
+          "50000": {
+            "description": "JNLP (Jave Web Start) Build executors port for slave agents not using SSH.",
+            "label": "Agent port [e.g. 50000]",
+            "host_default": 50000,
+            "protocol": "tcp"
+          },
+          "8080": {
+            "description": "Jenkins UI port.",
+            "label": "Server port [e.g. 8080]",
+            "host_default": 8080,
+            "protocol": "tcp",
+            "ui": true
+          }
         },
-        "website": "https://jenkins.io/",
-        "icon": "http://ftp-nyc.osuosl.org/pub/jenkins/art/jenkins-logo/128x128/logo.png",
-        "version": "2.528.3",
-        "containers": {
-            "jenkins": {
-                "image": "jenkins/jenkins",
-                "tag": "lts",
-                "launch_order": 1,
-                "uid": -1,
-                "gid": -1,
-                "ports": {
-                    "8080": {
-                        "description": "Jenkins UI port.",
-                        "host_default": 8080,
-                        "label": "Server port [e.g. 8080]",
-                        "protocol": "tcp",
-                        "ui": true
-                    },
-                    "50000": {
-                        "description": "JNLP (Jave Web Start) Build executors port for slave agents not using SSH.",
-                        "host_default": 50000,
-                        "label": "Agent port [e.g. 50000]",
-                        "protocol": "tcp"
-                    }
-                },
-                "volumes": {
-                    "/var/jenkins_home": {
-                        "description": "Jenkins storage. Jenkins will run as the user:group of this share e.g. (1000:1000).",
-                        "label": "Jenkins Home [e.g. jenkins-home]"
-                    }
-                }
-            }
+        "volumes": {
+          "/var/jenkins_home": {
+            "description": "Jenkins storage. Jenkins will run as the user:group of this share e.g. (1000:1000).",
+            "label": "Jenkins Home [e.g. jenkins-home]"
+          }
         }
+      }
     }
+  }
 }


### PR DESCRIPTION
The additional gid element mirrors the uid use of -1; indicating to use the full --user uid:gid CLI docker option.

Includes various user facing text normalisations and our newer format where relevant. Also removes an now out-dated warning regarding a Firefox incompatibility and work-around. Version updated to arbitrarily reflect the tested lts release. A minimum Rockstor version was added in the description to represent the gid use that only exists in the stated rpm version onwards.

Fixes #500

---

Draft status until a follow-up rockon-validation commit is applied; with the intent to clarify the non-format/ordering changes made in the first commit.