### PR TITLE
Add Newt Rock-on

### DIFF
--- a/newt.json
+++ b/newt.json
@@ -1,6 +1,6 @@
 {
     "Newt": {
-        "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'> https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
+        "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
         "ui": {
             "slug": ""
         },

--- a/newt.json
+++ b/newt.json
@@ -1,6 +1,6 @@
 {
   "Newt": {
-    "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
     "version": "1.8.1",
     "website": "https://github.com/fosrl/newt",
     "containers": {
@@ -14,11 +14,11 @@
           },
           "NEWT_ID": {
             "description": "Obtained from Pangolin server. The ID represents the site connection type in the system. Every Newt site has an ID.",
-            "label": "ID [e.g. ln8yqs6w85la5zg]"
+            "label": "ID [alphanumerics]"
           },
           "NEWT_SECRET": {
             "description": "Obtained from Pangolin server. The secret represents the “password” of the site. This secret must match the secret hashed in the system for the relevant ID.",
-            "label": "Secret [e.g. tfpwoc580jf1l1glfagix0o97p8kirjogdflqg604n0tr3to]"
+            "label": "Secret [alphanumerics]"
           }
         }
       }

--- a/newt.json
+++ b/newt.json
@@ -1,0 +1,30 @@
+{
+    "Newt": {
+        "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'> https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://github.com/fosrl/newt",
+        "version": "1.8.1",
+        "containers": {
+            "Newt": {
+                "image": "fosrl/newt",
+                "launch_order": 1,
+                "environment": {
+                    "PANGOLIN_ENDPOINT": {
+                        "label": "Endpoint",
+                        "description": "Example: https://app.pangolin.net or https://pangolin.my-server.com. This is the fully qualified hostname of the Pangolin server (the URL you use to access the dashboard). For Pangolin cloud, the endpoint is https://app.pangolin.net."
+                    },
+                    "NEWT_ID": {
+                        "label": "ID",
+                        "description": "Example: ln8yqs6w85la5zg. Obtained from Pangolin server. The ID represents the site connection type in the system. Every Newt site has an ID."
+                    },		    
+                    "NEWT_SECRET": {
+                        "label": "Secret",
+                        "description": "Example: tfpwoc580jf1l1glfagix0o97p8kirjogdflqg604n0tr3to. Obtained from Pangolin server. The secret represents the “password” of the site. This secret must match the secret hashed in the system for the relevant ID."
+                    }
+                }
+            }
+        }
+    }
+}

--- a/newt.json
+++ b/newt.json
@@ -1,30 +1,27 @@
 {
-    "Newt": {
-        "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
-        "ui": {
-            "slug": ""
-        },
-        "website": "https://github.com/fosrl/newt",
-        "version": "1.8.1",
-        "containers": {
-            "Newt": {
-                "image": "fosrl/newt",
-                "launch_order": 1,
-                "environment": {
-                    "PANGOLIN_ENDPOINT": {
-                        "label": "Endpoint",
-                        "description": "Example: https://app.pangolin.net or https://pangolin.my-server.com. This is the fully qualified hostname of the Pangolin server (the URL you use to access the dashboard). For Pangolin cloud, the endpoint is https://app.pangolin.net."
-                    },
-                    "NEWT_ID": {
-                        "label": "ID",
-                        "description": "Example: ln8yqs6w85la5zg. Obtained from Pangolin server. The ID represents the site connection type in the system. Every Newt site has an ID."
-                    },		    
-                    "NEWT_SECRET": {
-                        "label": "Secret",
-                        "description": "Example: tfpwoc580jf1l1glfagix0o97p8kirjogdflqg604n0tr3to. Obtained from Pangolin server. The secret represents the “password” of the site. This secret must match the secret hashed in the system for the relevant ID."
-                    }
-                }
-            }
+  "Newt": {
+    "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>https://hub.docker.com/r/fosrl/newt</a>, available for amd64 and arm64 architecture.</p>",
+    "version": "1.8.1",
+    "website": "https://github.com/fosrl/newt",
+    "containers": {
+      "Newt": {
+        "image": "fosrl/newt",
+        "launch_order": 1,
+        "environment": {
+          "PANGOLIN_ENDPOINT": {
+            "description": "This is the fully qualified hostname of the Pangolin server (the URL you use to access the dashboard). For Pangolin cloud, the endpoint is https://app.pangolin.net.",
+            "label": "Pangolin Endpoint [e.g. https://app.pangolin.net or https://pangolin.my-server.com]"
+          },
+          "NEWT_ID": {
+            "description": "Obtained from Pangolin server. The ID represents the site connection type in the system. Every Newt site has an ID.",
+            "label": "ID [e.g.ln8yqs6w85la5zg]"
+          },
+          "NEWT_SECRET": {
+            "description": "Obtained from Pangolin server. The secret represents the “password” of the site. This secret must match the secret hashed in the system for the relevant ID.",
+            "label": "Secret [e.g. tfpwoc580jf1l1glfagix0o97p8kirjogdflqg604n0tr3to]"
+          }
         }
+      }
     }
+  }
 }

--- a/newt.json
+++ b/newt.json
@@ -14,7 +14,7 @@
           },
           "NEWT_ID": {
             "description": "Obtained from Pangolin server. The ID represents the site connection type in the system. Every Newt site has an ID.",
-            "label": "ID [e.g.ln8yqs6w85la5zg]"
+            "label": "ID [e.g. ln8yqs6w85la5zg]"
           },
           "NEWT_SECRET": {
             "description": "Obtained from Pangolin server. The secret represents the “password” of the site. This secret must match the secret hashed in the system for the relevant ID.",

--- a/newt.json
+++ b/newt.json
@@ -1,6 +1,6 @@
 {
   "Newt": {
-    "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin cloud or with your own self-hosted Pangolin instance.</p><p>Based on the <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin Cloud or with your own self-hosted Pangolin instance.</p><p>Based on the <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
     "version": "1.8.1",
     "website": "https://github.com/fosrl/newt",
     "containers": {
@@ -9,7 +9,7 @@
         "launch_order": 1,
         "environment": {
           "PANGOLIN_ENDPOINT": {
-            "description": "This is the fully qualified hostname of the Pangolin server (the URL you use to access the dashboard). For Pangolin cloud, the endpoint is https://app.pangolin.net.",
+            "description": "This is the fully qualified hostname of the Pangolin server (the URL you use to access the dashboard). For Pangolin Cloud, the endpoint is https://app.pangolin.net.",
             "label": "Pangolin Endpoint [e.g. https://app.pangolin.net or https://pangolin.my-server.com]"
           },
           "NEWT_ID": {

--- a/newt.json
+++ b/newt.json
@@ -1,7 +1,7 @@
 {
   "Newt": {
     "description": "<p>Newt is a fully user space WireGuard tunnel client and TCP/UDP proxy, designed to securely expose private resources controlled by Pangolin. By using Newt, you don't need to manage complex WireGuard tunnels and NATing.</p><p>Can be used with Pangolin Cloud or with your own self-hosted Pangolin instance.</p><p>Based on the <a href='https://hub.docker.com/r/fosrl/newt' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "website": "https://github.com/fosrl/newt",
     "containers": {
       "Newt": {

--- a/root.json
+++ b/root.json
@@ -50,6 +50,7 @@
   "netalertx": "netalertx.json",
   "netbootxyz": "netbootxyz.json",
   "netdata (official)": "netdata-official.json",
+  "newt": "newt.json",
   "nextcloud-official": "nextcloud-official.json",
   "nginx": "nginx.json",
   "nginx-proxy-manager": "NginxProxyManager.json",


### PR DESCRIPTION
Extremely minimal rock-on for Newt, the service that connects to a Pangolin server. Wasn't sure how much to include in the descriptions, mostly sourced from their docs (https://docs.pangolin.net/manage/sites/credentials).

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Newt
- website: https://github.com/fosrl/newt
- description: Pangolin tunneled site & network connector. Can be used with Pangolin cloud or with a self-hosted Pangolin instance. Basically open source Cloudflare tunnels.

### Information on docker image
- docker image: https://hub.docker.com/r/fosrl/newt
- is an official docker image available for this project?: [X]


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website (the standard Pangolin website provides very little information about Newt)

###### As an aside, I based the formatting off of OpenSpeedTest.json and in that file there's an extra space after the `<a href>` tag, drives me nuts, but I'm not gonna do a whole pull request for that...