### PR TITLE
Add Stalwart Rock-on

### DIFF
--- a/root.json
+++ b/root.json
@@ -74,6 +74,7 @@
   "sonarr": "sonarr.json",
   "speedtest by openspeedtest": "OpenSpeedTest.json",
   "spoolman": "spoolman.json",
+  "stalwart": "stalwart.json",
   "syncthing": "syncthing.json",
   "tautulli": "tautulli.json",
   "teamspeak3": "teamspeak3.json",

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,0 +1,66 @@
+{
+    "Stalwart": {
+        "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>https://hub.docker.com/r/stalwartlabs/stalwart</a>, available for amd64 and arm64 architecture.</p>",
+        "ui": {
+            "slug": ""
+        },
+        "website": "https://stalw.art/",
+        "version": "0.15.4",
+        "containers": {
+            "Stalwart": {
+                "image": "stalwartlabs/stalwart",
+                "launch_order": 1,
+                "ports": {
+                    "443": {
+                        "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments. Suggested default: 10443",
+                        "host_default": 10443,
+                        "label": "HTTPS",
+                        "ui": false
+                    },
+                    "8080": {
+                        "description": "Provided mainly for initial setup. It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Suggested default: 18080",
+                        "host_default": 18080,
+                        "label": "HTTP",
+                        "ui": true
+                    },
+                    "25": {
+                        "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably. Suggested default: 10025",
+                        "host_default": 10025,
+                        "label": "SMTP"
+                    },
+                    "465": {
+                        "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587. Suggested default: 10465",
+                        "host_default": 10465,
+                        "label": "SMTPS"
+                    },
+                    "993": {
+                        "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval. Suggested default: 10993",
+                        "host_default": 10993,
+                        "label": "IMAPS"
+                    },
+                    "587": {
+                        "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security. Suggested default: 10587",
+                        "host_default": 10587,
+                        "label": "SMTP Submission"
+                    },
+                    "143": {
+                        "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993). Suggested default: 10143",
+                        "host_default": 10143,
+                        "label": "IMAP4"
+                    },
+                    "4190": {
+                        "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules. Suggested default: 104190",
+                        "host_default": 14190,
+                        "label": "ManageSieve"
+                    }
+                },
+                "volumes": {
+                    "/opt/stalwart": {
+                        "description": "Choose a Share for all Stalwart data. Eg: create a Share called stallwart-all for this purpose.",
+                        "label": "Storage"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,66 +1,62 @@
 {
-    "Stalwart": {
-        "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>https://hub.docker.com/r/stalwartlabs/stalwart</a>, available for amd64 and arm64 architecture.</p>",
-        "ui": {
-            "slug": ""
+  "Stalwart": {
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>https://hub.docker.com/r/stalwartlabs/stalwart</a>, available for amd64 and arm64 architecture.</p>",
+    "version": "0.15.4",
+    "website": "https://stalw.art/",
+    "containers": {
+      "Stalwart": {
+        "image": "stalwartlabs/stalwart",
+        "launch_order": 1,
+        "ports": {
+          "8080": {
+            "description": "Provided mainly for initial setup. It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Stalwart-cli may require this port to be set to 8080 for certain functions.",
+            "label": "HTTP [e.g. 18080]",
+            "host_default": 18080,
+            "ui": true
+          },
+          "443": {
+            "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments.",
+            "label": "HTTPS [e.g. 10443]",
+            "host_default": 10443
+          },
+          "143": {
+            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port (10993).",
+            "label": "IMAP4 [e.g. 10143]",
+            "host_default": 10143
+          },
+          "25": {
+            "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably.",
+            "label": "SMTP [e.g. 10025]",
+            "host_default": 10025
+          },
+          "465": {
+            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port 10587.",
+            "label": "SMTPS [e.g. 10465]",
+            "host_default": 10465
+          },
+          "587": {
+            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security.",
+            "label": "SMTP Submission [e.g. 10587]",
+            "host_default": 10587
+          },
+          "993": {
+            "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval.",
+            "label": "IMAPS [e.g. 10993]",
+            "host_default": 10993
+          },
+          "4190": {
+            "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules.",
+            "label": "ManageSieve [e.g. 14190]",
+            "host_default": 14190
+          }
         },
-        "website": "https://stalw.art/",
-        "version": "0.15.4",
-        "containers": {
-            "Stalwart": {
-                "image": "stalwartlabs/stalwart",
-                "launch_order": 1,
-                "ports": {
-                    "443": {
-                        "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments. Suggested default: 10443",
-                        "host_default": 10443,
-                        "label": "HTTPS",
-                        "ui": false
-                    },
-                    "8080": {
-                        "description": "Provided mainly for initial setup. It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Suggested default: 18080",
-                        "host_default": 18080,
-                        "label": "HTTP",
-                        "ui": true
-                    },
-                    "25": {
-                        "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably. Suggested default: 10025",
-                        "host_default": 10025,
-                        "label": "SMTP"
-                    },
-                    "465": {
-                        "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587. Suggested default: 10465",
-                        "host_default": 10465,
-                        "label": "SMTPS"
-                    },
-                    "993": {
-                        "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval. Suggested default: 10993",
-                        "host_default": 10993,
-                        "label": "IMAPS"
-                    },
-                    "587": {
-                        "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security. Suggested default: 10587",
-                        "host_default": 10587,
-                        "label": "SMTP Submission"
-                    },
-                    "143": {
-                        "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993). Suggested default: 10143",
-                        "host_default": 10143,
-                        "label": "IMAP4"
-                    },
-                    "4190": {
-                        "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules. Suggested default: 104190",
-                        "host_default": 14190,
-                        "label": "ManageSieve"
-                    }
-                },
-                "volumes": {
-                    "/opt/stalwart": {
-                        "description": "Choose a Share for all Stalwart data. Eg: create a Share called stallwart-all for this purpose.",
-                        "label": "Storage"
-                    }
-                }
-            }
+        "volumes": {
+          "/opt/stalwart": {
+            "description": "Choose a Share for all Stalwart data.",
+            "label": "Storage [e.g. stalwart-all]"
+          }
         }
+      }
     }
+  }
 }

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,6 +1,6 @@
 {
   "Stalwart": {
-    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the official docker image: <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>https://hub.docker.com/r/stalwartlabs/stalwart</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
     "version": "0.15.4",
     "website": "https://stalw.art/",
     "containers": {

--- a/stalwart.json
+++ b/stalwart.json
@@ -35,7 +35,7 @@
             "host_default": 10465
           },
           "587": {
-            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security.",
+            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port 10587 can be disabled for simplicity and security.",
             "label": "SMTP Submission [e.g. 10587]",
             "host_default": 10587
           },

--- a/stalwart.json
+++ b/stalwart.json
@@ -18,7 +18,7 @@
             "ui": false
           },
           "8080": {
-            "description": "Administration login (for setup, settings changes, etc.). It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access.",
+            "description": "Administration login (for setup, settings changes, etc.). It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Stalwart-cli may require this port to be set to 8080 for certain functions.",
             "host_default": 18080,
             "label": "HTTP [e.g. 18080]",
             "ui": true
@@ -29,7 +29,7 @@
             "label": "SMTP [e.g. 10025]"
           },
           "465": {
-            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587.",
+            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to the SMTP port.",
             "host_default": 10465,
             "label": "SMTPS [e.g. 10465]"
           },
@@ -39,12 +39,12 @@
             "label": "IMAPS [e.g. 10993]"
           },
           "587": {
-            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security.",
+            "description": "Handles email submission using STARTTLS. If all your clients are configured to use the SMTPS port with implicit TLS, this port can be disabled for simplicity and security.",
             "host_default": 10587,
             "label": "SMTP Submission [e.g. 10587]"
           },
           "143": {
-            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993).",
+            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port.",
             "host_default": 10143,
             "label": "IMAP4 [e.g. 10143]"
           },

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,6 +1,6 @@
 {
   "Stalwart": {
-    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Run <code>chown 2000:2000</code> on the Stalwart shares [e.g. <code>chown 2000:2000 /mnt2/stalwart-config /mnt2/stalwart-data</code>] before setup.</p><p>Use <code>docker logs stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Run <code>chown 2000:2000</code> on the Stalwart shares [e.g. <code>chown 2000:2000 /mnt2/stalwart-config /mnt2/stalwart-data</code>] before setup.</p><p>Use <code>docker logs stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker/#retrieve-the-administrator-credentials' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
     "ui": {
       "slug": "admin"
     },

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,6 +1,6 @@
 {
   "Stalwart": {
-    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
     "ui": {
       "slug": "admin"
     },

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,6 +1,6 @@
 {
   "Stalwart": {
-    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Run <code>chown 2000:2000</code> on the Stalwart shares [e.g. <code>chown 2000:2000 /mnt2/stalwart-config /mnt2/stalwart-data</code>] before setup.</p><p>Use <code>docker logs stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
     "ui": {
       "slug": "admin"
     },

--- a/stalwart.json
+++ b/stalwart.json
@@ -12,46 +12,46 @@
         "launch_order": 1,
         "ports": {
           "443": {
-            "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments. Suggested default: 10443",
+            "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments.",
             "host_default": 10443,
-            "label": "HTTPS",
+            "label": "HTTPS [e.g. 10443]",
             "ui": false
           },
           "8080": {
-            "description": "Administration login (for setup, settings changes, etc.). It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Suggested default: 18080",
+            "description": "Administration login (for setup, settings changes, etc.). It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access.",
             "host_default": 18080,
-            "label": "HTTP",
+            "label": "HTTP [e.g. 18080]",
             "ui": true
           },
           "25": {
-            "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably (must not be 25 due to local conflicts). Suggested default: 10025",
+            "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably (must not be 25 due to local conflicts).",
             "host_default": 10025,
-            "label": "SMTP"
+            "label": "SMTP [e.g. 10025]"
           },
           "465": {
-            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587. Suggested default: 10465",
+            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587.",
             "host_default": 10465,
-            "label": "SMTPS"
+            "label": "SMTPS [e.g. 10465]"
           },
           "993": {
-            "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval. Suggested default: 10993",
+            "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval.",
             "host_default": 10993,
-            "label": "IMAPS"
+            "label": "IMAPS [e.g. 10993]"
           },
           "587": {
-            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security. Suggested default: 10587",
+            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security.",
             "host_default": 10587,
-            "label": "SMTP Submission"
+            "label": "SMTP Submission [e.g. 10587]"
           },
           "143": {
-            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993). Suggested default: 10143",
+            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993).",
             "host_default": 10143,
-            "label": "IMAP4"
+            "label": "IMAP4 [e.g. 10143]"
           },
           "4190": {
-            "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules. Suggested default: 104190",
+            "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules.",
             "host_default": 14190,
-            "label": "ManageSieve"
+            "label": "ManageSieve [e.g. 14190]"
           }
         },
         "volumes": {

--- a/stalwart.json
+++ b/stalwart.json
@@ -1,59 +1,67 @@
 {
   "Stalwart": {
-    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code> for admin setup. See https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface for more</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official docker image</a>, available for amd64 and arm64 architecture.</p>",
-    "version": "0.15.4",
+    "description": "<p>Stalwart is an open-source mail & collaboration server with JMAP, IMAP4, POP3, SMTP, CalDAV, CardDAV and WebDAV support and a wide range of modern features. It is written in Rust and designed to be secure, fast, robust and scalable.</p><p>Use <code>docker logs Stalwart</code>for admin <a href='https://stalw.art/docs/install/platform/docker#log-in-to-the-web-interface' target='_blank'>setup</a>.</p><p>Based on the <a href='https://hub.docker.com/r/stalwartlabs/stalwart' target='_blank'>official OCI image</a>, available for amd64 and arm64 architecture.</p>",
+    "ui": {
+      "slug": "admin"
+    },
     "website": "https://stalw.art/",
+    "version": "0.16.2",
     "containers": {
-      "Stalwart": {
+      "stalwart": {
         "image": "stalwartlabs/stalwart",
         "launch_order": 1,
         "ports": {
+          "443": {
+            "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments. Suggested default: 10443",
+            "host_default": 10443,
+            "label": "HTTPS",
+            "ui": false
+          },
           "8080": {
-            "description": "Provided mainly for initial setup. It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Stalwart-cli may require this port to be set to 8080 for certain functions.",
-            "label": "HTTP [e.g. 18080]",
+            "description": "Administration login (for setup, settings changes, etc.). It is strongly recommended to disable this port after setup is complete to prevent unauthenticated, unencrypted access. Suggested default: 18080",
             "host_default": 18080,
+            "label": "HTTP",
             "ui": true
           },
-          "443": {
-            "description": "A critical port used for multiple secure web-based services, including web administration, JMAP, REST API, OAuth, TLS certificate provisioning (ACME challenges), autoconfig, and MTA-STS. This port must remain open in nearly all deployments.",
-            "label": "HTTPS [e.g. 10443]",
-            "host_default": 10443
-          },
-          "143": {
-            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port (10993).",
-            "label": "IMAP4 [e.g. 10143]",
-            "host_default": 10143
-          },
           "25": {
-            "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably.",
-            "label": "SMTP [e.g. 10025]",
-            "host_default": 10025
+            "description": "Used for receiving email from other mail servers. This port must remain open for your domain to receive external email traffic reliably (must not be 25 due to local conflicts). Suggested default: 10025",
+            "host_default": 10025,
+            "label": "SMTP"
           },
           "465": {
-            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port 10587.",
-            "label": "SMTPS [e.g. 10465]",
-            "host_default": 10465
-          },
-          "587": {
-            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port 10587 can be disabled for simplicity and security.",
-            "label": "SMTP Submission [e.g. 10587]",
-            "host_default": 10587
+            "description": "Handles email submission with implicit TLS encryption. Recommended for securely sending outgoing mail from user clients. It is best to keep this port open and use it in preference to port (10)587. Suggested default: 10465",
+            "host_default": 10465,
+            "label": "SMTPS"
           },
           "993": {
-            "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval.",
-            "label": "IMAPS [e.g. 10993]",
-            "host_default": 10993
+            "description": "IMAP over implicit TLS. Required for secure email access via IMAP clients. Keep this port open to allow encrypted mail retrieval. Suggested default: 10993",
+            "host_default": 10993,
+            "label": "IMAPS"
+          },
+          "587": {
+            "description": "Handles email submission using STARTTLS. If all your clients are configured to use port (10)465 with implicit TLS, port (10)587 can be disabled for simplicity and security. Suggested default: 10587",
+            "host_default": 10587,
+            "label": "SMTP Submission"
+          },
+          "143": {
+            "description": "The standard IMAP port without encryption. This port should generally be disabled in favor of the encrypted IMAPS port ((10)993). Suggested default: 10143",
+            "host_default": 10143,
+            "label": "IMAP4"
           },
           "4190": {
-            "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules.",
-            "label": "ManageSieve [e.g. 14190]",
-            "host_default": 14190
+            "description": "Used to manage Sieve scripts remotely. Only keep this port open if your users actively use Sieve for email filtering rules. Suggested default: 104190",
+            "host_default": 14190,
+            "label": "ManageSieve"
           }
         },
         "volumes": {
-          "/opt/stalwart": {
-            "description": "Choose a Share for all Stalwart data.",
-            "label": "Storage [e.g. stalwart-all]"
+          "/etc/stalwart": {
+            "description": "This is where the Stalwart configuration will be stored (2000:2000).",
+            "label": "Configuration [e.g. stalwart-config]"
+          },
+          "/var/lib/stalwart": {
+            "description": "This is where the Stalwart data will be stored (2000:2000).",
+            "label": "Data [e.g. stalwart-data]"
           }
         }
       }


### PR DESCRIPTION
Had my go at finally creating a mailserver rock-on. Wasn't sure how to deal with mail port numbers, just made them all 10000+. Technically only the HTTP and HTTPS should need reassignment, but for some reason there is a conflict for SMTP port 25, so to be cautious I made them all big.
I'm unsure how to make ports optional, so the descriptions suggesting disabling ports may be misleading.

### General information on project
This pull request proposes to add a new rock-on for the following project:
- name: Stalwart
- website: https://stalw.art/
- description: Rockstor lacks any mailserver rock-ons... until now! Stalwart is written in Rust, supports JMAP, and comes recommended by PrivacyGuides.org. Can be used, for example, to act as the server for Nextcloud Mail (even purely locally).

### Information on docker image
- docker image: https://hub.docker.com/r/stalwartlabs/stalwart
- is an official docker image available for this project?: yep


### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [X] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the docker image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website