### PR TITLE
Fix my review typo in new RustFS Rock-on #507

### DIFF
--- a/rustfs.json
+++ b/rustfs.json
@@ -1,6 +1,6 @@
 {
   "RustFS": {
-    "description": "RustFS is an S3-compatible object storage server. <a href='https://rockstor.com/docs/interface/docker-based-rock-ons/rustfs.html.html' target='_blank'>Rock-on guide</a>.  Based on the <a href='https://hub.docker.com/r/rustfs/rustfs' target='_blank'>official Docker image</a>, available for amd64 and arm64 architecture.",
+    "description": "RustFS is an S3-compatible object storage server. <a href='https://rockstor.com/docs/interface/docker-based-rock-ons/rustfs.html' target='_blank'>Rock-on guide</a>.<p>Based on the <a href='https://hub.docker.com/r/rustfs/rustfs' target='_blank'>official Docker image</a>, available for amd64 and arm64 architecture.</p>",
     "version": "1.0",
     "website": "https://rustfs.com",
     "more_info": "This Rock-on uses the official RustFS Docker image to implement a single RustFS instance with a single object storage share, suitable for use on a private network. If your connections traverse a network you do not control, consider using a VPN for encryption.",


### PR DESCRIPTION
Also includes a paragraph formatting normalisation around our:
- Based on ..., available for ... Rockstor V#.#.# or later.

Fixes #507

