### PR TITLE
Interim reset of image source back to github (#517)

### DIFF
--- a/WireGuardEasy.json
+++ b/WireGuardEasy.json
@@ -5,7 +5,7 @@
     "website": "https://wg-easy.github.io/wg-easy/latest/",
     "containers": {
       "WireGuardEasy": {
-        "image": "codeberg.org/wg-easy/wg-easy",
+        "image": "ghcr.io/wg-easy/wg-easy",
         "launch_order": 1,
         "ports": {
           "51820": {


### PR DESCRIPTION
Interim Fix for #517.
### Information on OCI image
- OCI image: reset OCI image back to github source until WGEasy v15.x Rock-on definition can be updated.

### Checklist
- [X] Passes [JSONlint](https://jsonlint.com) validation
- [ ] Entry added to `root.json` in _alphabetical_ order (for new rock-on only)
- [X] `"description"` object lists and links to the OCI image used
- [X] `"description"` object provides information on the image's particularities (advantage over another existing rock-on for the same project, for instance)
- [X] `"website"` object links to project's main website
