### PR TITLE
Remove use of non-existent 'default' element #530

### DIFF
--- a/airsonic-advanced.json
+++ b/airsonic-advanced.json
@@ -48,14 +48,12 @@
           "PGID": {
             "description": "Enter a valid GID of an existing user with permission to media shares to run Airsonic as..",
             "label": "GID [e.g. 100]",
-            "index": 3,
-            "default": "100"
+            "index": 3
           },
           "PUID": {
             "description": "Enter a valid UID of an existing user with permission to media shares to run Airsonic as..",
             "label": "UID [e.g. 1001]",
-            "index": 2,
-            "default": "1001"
+            "index": 2
           }
         }
       }

--- a/calibre.json
+++ b/calibre.json
@@ -49,20 +49,17 @@
           "LC_ALL": {
             "description": "Which locale to start Calibre in, using utf8 (e.g., zh_CN.UTF-8). If in US English, enter 'en_US.UTF-8'. The language can still be adjusted within Calibre's startup wizard.",
             "label": "Locale installs [e.g. en_US.UTF-8]",
-            "index": 3,
-            "default": "en_US.UTF-8"
+            "index": 3
           },
           "PGID": {
             "description": "Enter a valid GID of an existing group with permission to the config share assigned above.",
             "label": "GID",
-            "index": 2,
-            "default": "1000"
+            "index": 2
           },
           "PUID": {
             "description": "Enter a valid UID of an existing user with permission to the config share assigned above.",
             "label": "UID",
-            "index": 1,
-            "default": "1000"
+            "index": 1
           }
         },
         "devices": {

--- a/embyserver.json
+++ b/embyserver.json
@@ -44,20 +44,17 @@
           "GID": {
             "description": "GID of an existing user with permission to media shares to run Emby as.",
             "label": "GID",
-            "index": 2,
-            "default": "100"
+            "index": 2
           },
           "GIDLIST": {
             "description": "Enter a comma-separated list of additional GIDs to run emby as",
             "label": "GIDList",
-            "index": 3,
-            "default": "100"
+            "index": 3
           },
           "UID": {
             "description": "UID of an existing user with permission to media shares to run Emby as.",
             "label": "UID",
-            "index": 1,
-            "default": "1000"
+            "index": 1
           }
         },
         "devices": {

--- a/jellyfin-linuxserver.json
+++ b/jellyfin-linuxserver.json
@@ -50,14 +50,12 @@
           "PGID": {
             "description": "GID of an existing user with permission to media shares to run Jellyfin as.",
             "label": "GID",
-            "index": 2,
-            "default": "1000"
+            "index": 2
           },
           "PUID": {
             "description": "UID of an existing user with permission to media shares to run Jellyfin as.",
             "label": "UID",
-            "index": 1,
-            "default": "1000"
+            "index": 1
           }
         },
         "devices": {

--- a/netdata-official.json
+++ b/netdata-official.json
@@ -51,8 +51,7 @@
           "PGID": {
             "description": "GID of the 'docker' group. See System - Identity - Groups in Rockstor's UI to find it.",
             "label": "PGID",
-            "index": 1,
-            "default": "472"
+            "index": 1
           }
         }
       }

--- a/wsdd.json
+++ b/wsdd.json
@@ -22,8 +22,7 @@
           "WSDDN_WORKGROUP": {
             "description": "Workgroup name. Must be the same name used during the setup of the Samba service on the Rockstor appliance.",
             "label": "Workgroup [e.g. WORKGROUP]",
-            "index": 2,
-            "default": "WORKGROUP"
+            "index": 2
           }
         }
       }


### PR DESCRIPTION
Via the rockon-validator, post a recent fix, we have the following changes regarding prior use of the non-existent container.environment.default element.

Fixes #530

---

The rockon-validator was applied to the known instances (found via `grep "\"default\":" *`)  as follows:

```
podman pull ghcr.io/rockstor/rockon-validator:main
podman run -v $(pwd):/files:Z ghcr.io/rockstor/rockon-validator:main --write airsonic-advanced.json calibre.json embyserver.json jellyfin-linuxserver.json netdata-official.json wsdd.json
```

Resulting in a re-written, but not otherwise content modified root.json also.

---

Re: "... post a recent fix, ..." see:
- https://github.com/rockstor/rockon-validator/pull/59
